### PR TITLE
Spread loaded modules on `require` compatibility

### DIFF
--- a/lib/system-amd-production.js
+++ b/lib/system-amd-production.js
@@ -84,7 +84,9 @@
     if (names instanceof Array)
       Promise.all(names.map(function(name) {
         return System.import(name, referer);
-      })).then(callback, errback);
+      })).then(function(mods) {
+        return callback.apply(this, mods);
+      }, errback);
 
     // commonjs require
     else if (typeof names == 'string')


### PR DESCRIPTION
A `Promise.all`-created promise resolves to a single array that contains all results. To maintain requirejs API compatibility, we need to unpack the results into multiple arguments.
