### PR TITLE
Support System.register modules in CSP build

### DIFF
--- a/test/test-csp-production.html
+++ b/test/test-csp-production.html
@@ -48,6 +48,14 @@
         }, err);
       });
 
+      asyncTest('System.register Circular', function() {
+        System['import']('tests/register-circular1').then(function(m) {
+          ok(m.q == 3, 'Binding not allocated');
+          ok(m.r == 5, 'Binding not updated');
+          start();
+        }, err);
+      });
+
       asyncTest('Loading a UMD module', function() {
         System['import']('tests/umd').then(function(m) {
           ok(m.d == 'hi');


### PR DESCRIPTION
Hey @guybedford, trying the latest and greatest again.

This could just be me being confused, but I'd like to use the `System.register` format. However it just fails with a `Include Traceur for module syntax support` error. I don't really understand the error because the module has already been transpiled to ES5 syntax.

![screen shot 2014-05-09 at 5 16 37 pm](https://cloud.githubusercontent.com/assets/137/2933452/3bc5aeba-d7bf-11e3-8653-152b42c1105f.png)
