### PR TITLE
Update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/system.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/guybedford/systemjs"
+    "url": "git://github.com/systemjs/systemjs"
   },
   "author": "Guy Bedford",
   "license": "MIT",


### PR DESCRIPTION
Even if Github automatically redirects old repository URL to new one, it is prefered that package.json shows the latest information correctly.
