### PR TITLE
Detect AMD modules even in the presence of comments in deps list

### DIFF
--- a/lib/extension-amd.js
+++ b/lib/extension-amd.js
@@ -10,7 +10,7 @@ function amd(loader) {
   // AMD Module Format Detection RegEx
   // define([.., .., ..], ...)
   // define(varName); || define(function(require, exports) {}); || define({})
-  var amdRegEx = /(?:^\s*|[}{\(\);,\n\?\&]\s*)define\s*\(\s*("[^"]+"\s*,\s*|'[^']+'\s*,\s*)?\s*(\[(\s*("[^"]+"|'[^']+')\s*,)*(\s*("[^"]+"|'[^']+')\s*,?\s*)?\]|function\s*|{|[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*\))/;
+  var amdRegEx = /(?:^\s*|[}{\(\);,\n\?\&]\s*)define\s*\(\s*("[^"]+"\s*,\s*|'[^']+'\s*,\s*)?\s*(\[(\s*(("[^"]+"|'[^']+')\s*,|\/\/.*\n|\/\*(.|\s)*?\*\/))*(\s*("[^"]+"|'[^']+')\s*,?\s*)?(\s*(\/\/.*\n|\/\*(.|\s)*?\*\/)\s*)*\]|function\s*|{|[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*\))/;
 
   /*
     AMD-compatible require

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,13 @@ asyncTest('AMD detection test', function() {
   }, err);
 });
 
+asyncTest('AMD detection test with comments', function() {
+  System['import']('tests/amd-module-3').then(function(m) {
+    ok(m.amd);
+    start();
+  }, err);
+});
+
 System.bundles['tests/amd-bundle'] = ['bundle-1', 'bundle-2'];
 asyncTest('Loading an AMD bundle', function() {
   System['import']('bundle-1').then(function(m) {

--- a/test/tests/amd-module-3.js
+++ b/test/tests/amd-module-3.js
@@ -1,0 +1,13 @@
+define([
+  // with a single-line comment
+  './amd-module',
+  /* with a multi-line
+     comment
+   */
+  './amd-module'
+  // trailing single-line comment
+  /* trailing multi-line
+     comment */
+], function () {
+  return { amd: true };
+});


### PR DESCRIPTION
Improved the detection of AMD modules slightly to work even when there are comments in the middle of the list of dependencies.

Note that the regexp is getting a bit large, is there any plan to use something like esprima instead?
