### PR TITLE
[Fix] Incorrect arguments Array for AMD modules

### DIFF
--- a/lib/extension-amd.js
+++ b/lib/extension-amd.js
@@ -120,7 +120,7 @@ function amd(loader) {
 
           // add back in system dependencies
           if (moduleIndex != -1)
-            depValues.splice(moduleIndex, 0, exports, module = { id: moduleName, uri: loader.baseURL + moduleName, config: function() { return {}; }, exports: exports });
+            depValues.splice(moduleIndex, 0, module = { id: moduleName, uri: loader.baseURL + moduleName, config: function() { return {}; }, exports: exports });
           
           if (exportsIndex != -1)
             depValues.splice(exportsIndex, 0, exports);


### PR DESCRIPTION
AMD modules using the `define(require, exports, module)` style are currently called with a malformed arguments array that accidentally contains `exports` twice. Modules using the `module.exports = ...` style thus don't work.
