### PR TITLE
[FIX] Remove webkitStorageInfo is deprecated warning

### DIFF
--- a/lib/extension-global.js
+++ b/lib/extension-global.js
@@ -33,8 +33,9 @@ function global(loader) {
         // now store a complete copy of the global object
         // in order to detect changes
         curGlobalObj = {};
-        ignoredGlobalProps = ['indexedDB', 'sessionStorage', 'localStorage', 'clipboardData', 'frames'];
-        for (var g in loader.global)
+        ignoredGlobalProps = ['indexedDB', 'sessionStorage', 'localStorage', 'clipboardData', 'frames', 'webkitStorageInfo'];
+        for (var g in loader.global) {
+          if (~ignoredGlobalProps.indexOf(g)) { continue; }
           if (!hasOwnProperty || loader.global.hasOwnProperty(g)) {
             try {
               curGlobalObj[g] = loader.global[g];
@@ -42,6 +43,7 @@ function global(loader) {
               ignoredGlobalProps.push(g);
             }
           }
+        }
       },
       retrieveGlobal: function(moduleName, exportName, init) {
         var singleGlobal;


### PR DESCRIPTION
Chrome always prints the warning:

```
'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.
```

Since this is distracting, this PR makes the warning disappear.
