### PR TITLE
commonjs exports fix, dynamic register adjustments

### DIFF
--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -71,7 +71,7 @@ function cjs(loader) {
 
       load.metadata.executingRequire = true;
 
-      load.metadata.execute = function(require, exports, moduleName) {
+      load.metadata.execute = function(require, exports, module) {
         var dirname = (load.address || '').split('/');
         dirname.pop();
         dirname = dirname.join('/');
@@ -79,7 +79,7 @@ function cjs(loader) {
         var globals = loader.global._g = {
           global: loader.global,
           exports: exports,
-          module: { exports: exports },
+          module: module,
           process: nodeProcess,
           require: require,
           __filename: load.address,
@@ -101,8 +101,6 @@ function cjs(loader) {
         loader.global.define = define;
 
         loader.global._g = undefined;
-
-        return globals.module.exports;
       }
     }
 

--- a/lib/extension-register.js
+++ b/lib/extension-register.js
@@ -337,7 +337,7 @@ function register(loader) {
       exports = entry.module.exports;
     }
 
-    return exports.__useDefault ? exports['default'] : exports;
+    return exports;
   }
 
   function linkDynamicModule(entry, loader) {
@@ -345,9 +345,8 @@ function register(loader) {
       return;
 
     var exports = {};
-    var module = { 'default': exports, __useDefault: true };
 
-    entry.module = { exports: module };
+    var module = entry.module = { exports: exports, id: entry.name };
 
     // AMD requires execute the tree first
     if (!entry.executingRequire) {
@@ -359,9 +358,6 @@ function register(loader) {
       }
     }
 
-    // lookup the module name if it is in the registry
-    var moduleName = entry.name;
-
     // now execute
     entry.evaluated = true;
     var output = entry.execute.call(loader.global, function(name) {
@@ -370,10 +366,10 @@ function register(loader) {
           continue;
         return getModule(entry.normalizedDeps[i], loader);
       }
-    }, exports, moduleName);
+    }, exports, module);
     
     if (output)
-      module['default'] = output;
+      module.exports = output;
   }
 
   /*
@@ -547,7 +543,7 @@ function register(loader) {
           // remove from the registry
           loader.defined[load.name] = undefined;
 
-          var module = loader.newModule(entry.module.exports);
+          var module = loader.newModule(entry.declarative ? entry.module.exports : { 'default': entry.module.exports, '__useDefault': true });
           entry.module.module = module;
 
           // if the entry is an alias, set the alias too

--- a/test/test.js
+++ b/test/test.js
@@ -252,6 +252,13 @@ asyncTest('Loading a CommonJS module with this', function() {
   }, err);
 });
 
+asyncTest('CommonJS setting module.exports', function() {
+  System['import']('tests/cjs-exports').then(function(m) {
+    ok(m.e = 'export');
+    start();
+  }, err);
+});
+
 asyncTest('Loading a UMD module', function() {
   System['import']('tests/umd').then(function(m) {
     ok(m.d == 'hi', 'module value not defined');

--- a/test/tests/cjs-exports-dep.js
+++ b/test/tests/cjs-exports-dep.js
@@ -1,0 +1,1 @@
+exports.e = require('./cjs-exports')();

--- a/test/tests/cjs-exports.js
+++ b/test/tests/cjs-exports.js
@@ -1,0 +1,6 @@
+module.exports = F;
+require('./cjs-exports-dep');
+function F() {
+  return 'export';
+}
+module.exports = require('./cjs-exports-dep');


### PR DESCRIPTION
This adjusts the execute function for dynamic System.register to take argument - `require, exports, module`.

The `module` object is carefully designed to support setting via `module.exports = ...` to allow dynamic exports changing in CommonJS. This object could also be decorated with other properties by a CommonJS compatibility layer if desired allowing it to be the same as the CommonJS `module` object effectively.

The associated pipeline changes are made to support this form.

Fixes https://github.com/systemjs/systemjs/issues/136
