### PR TITLE
Fixes bower.json missing "main" entry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "system.js",
   "version": "0.6.8",
+  "main": "dist/system.js",
   "dependencies": {
     "es6-module-loader": "~0.7.2"
   },


### PR DESCRIPTION
Bower complains when a dependency doesn't have a `main`.
