### PR TITLE
Add new line before CJS source

### DIFF
--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -55,7 +55,7 @@ function cjs(loader) {
           __dirname: dirname
         };
 
-        load.source = '(function(global, exports, module, require, __filename, __dirname) { ' + load.source 
+        load.source = '(function(global, exports, module, require, __filename, __dirname) {\n ' + load.source 
           + '\n}).call(_g.exports, _g.global, _g.exports, _g.module, _g.require, _g.__filename, _g.__dirname);';
 
         // disable AMD detection


### PR DESCRIPTION
This makes debugging CJS a little nicer with the wrapper adding a new
line before the user's source. Hopefully this is a non-controversial
change.
