### PR TITLE
Allow script-injected SystemJS to work

### DIFF
--- a/lib/polyfill-wrapper-end.js
+++ b/lib/polyfill-wrapper-end.js
@@ -55,10 +55,38 @@ var $__curScript, __eval;
     if (!$__global.System || !$__global.LoaderPolyfill) {
       // determine the current script path as the base path
       var curPath = $__curScript.src;
-      var basePath = curPath.substr(0, curPath.lastIndexOf('/') + 1);
-      document.write(
-        '<' + 'script type="text/javascript" src="' + basePath + 'es6-module-loader.js" data-init="upgradeSystemLoader">' + '<' + '/script>'
-      );
+
+      if(curPath.length) {
+        var basePath = curPath.substr(0, curPath.lastIndexOf('/') + 1);
+        document.write(
+          '<' + 'script type="text/javascript" src="' + basePath + 'es6-module-loader.js" data-init="upgradeSystemLoader">' + '<' + '/script>'
+        );
+      }
+      // SystemJS loaded through script injection.
+      else {
+        var systemScript;
+        for(var i = 0, len = scripts.length; i < len; i++) {
+          if(/system.js/.test(scripts[i].src)) {
+            systemScript = scripts[i];
+            curPath = systemScript.src;
+          }
+        }
+        var basePath = curPath.substr(0, curPath.lastIndexOf('/') + 1);
+        var esmlScript = document.createElement('script');
+        esmlScript.src = basePath + 'es6-module-loader.js';
+        esmlScript.setAttribute('data-init', 'upgradeSystemLoader');
+        // If someone is listening for the script to load, provide that once
+        // es6-module-loader is finished.
+        var oldOnload = systemScript.onload;
+        systemScript.onload = function() {
+          esmlScript.onload = function(evt) {
+            if(oldOnload) oldOnload.apply(this, arguments);
+          };
+        };
+
+        var head = document.head || document.getElementsByTagName('head')[0];
+        head.appendChild(esmlScript);
+      }
     }
     else {
       $__global.upgradeSystemLoader();

--- a/test/test.js
+++ b/test/test.js
@@ -569,4 +569,22 @@ if(typeof window !== 'undefined' && window.Worker) {
   });
 }
 
+if(typeof window !== 'undefined') {
+  asyncTest('Loading through script injection', function() {
+    var testArea = document.getElementById('qunit-test-area');
+    var iframe = document.createElement('iframe');
+    iframe.src = 'tests/script-injected/test.html';
+
+    testArea.appendChild(iframe);
+
+    iframe.contentWindow.callMe = function() {
+      ok(true);
+      // cleanup
+      testArea.innerHTML = '';
+
+      start();
+    };
+  });
+}
+
 })();

--- a/test/tests/script-injected/es6-module-loader.js
+++ b/test/tests/script-injected/es6-module-loader.js
@@ -1,0 +1,1 @@
+../../../bower_components/es6-module-loader/dist/es6-module-loader.js

--- a/test/tests/script-injected/system.js
+++ b/test/tests/script-injected/system.js
@@ -1,0 +1,1 @@
+../../../dist/system.js

--- a/test/tests/script-injected/test.coffee
+++ b/test/tests/script-injected/test.coffee
@@ -1,0 +1,1 @@
+../bootstrap@3.1.1/test.coffee

--- a/test/tests/script-injected/test.html
+++ b/test/tests/script-injected/test.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <title>Script injecting System.js</title>
+</head>
+<body>
+
+  <script>
+    var ss = document.createElement('script');
+    ss.src = 'system.js';
+    document.head.appendChild(ss);
+
+    ss.onload = function() {
+      // Try to import something.
+      if(typeof System !== 'undefined') {
+        window.callMe();
+      };
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This fixes #177 by using script-injection of es6-module-loader rather
than document.write in cases where the script (SystemJS). Have to
slightly compromise and overload the script's `onload` to be called
after the es6-module-loader script has loaded.
