### PR TITLE
Global module dependency shim layer

### DIFF
--- a/lib/extension-global.js
+++ b/lib/extension-global.js
@@ -3,83 +3,99 @@
 
   Supports
     metadata.deps
-    metadata.init
     metadata.exports
+
+  As well as additional globals that should be defined from existing module values:
+
+    metadata.globals = {
+      $: 'jquery'
+    }
 
   Also detects writes to the global object avoiding global collisions.
   See the SystemJS readme global support section for further information.
 */
 function global(loader) {
+
+  var global = loader.global;
+
+  var ignoredGlobalProps = ['indexedDB', 'sessionStorage', 'localStorage', 'clipboardData', 'frames', 'webkitStorageInfo', 'errorOnAccess'];
+  // dummy variable to ensure access below isn't optimized out
+  var lastGlobal;
+  var hasOwnProperty = loader.global.hasOwnProperty;
+  function allowedGlobal(p) {
+    if (indexOf.call(ignoredGlobalProps, p) != -1)
+      return false;
+    if (hasOwnProperty && !global.hasOwnProperty(p))
+      return false;
+    try {
+      lastGlobal = global[p];
+      return true;
+    }
+    catch(e) {
+      ignoredGlobalProps.push(p);
+      return false;
+    }
+  }
+
   function createHelpers(loader) {
     if (loader.has('@@global-helpers'))
       return;
 
-    var hasOwnProperty = loader.global.hasOwnProperty;
     var moduleGlobals = {};
 
     var curGlobalObj;
-    var ignoredGlobalProps;
 
     loader.set('@@global-helpers', loader.newModule({
-      prepareGlobal: function(moduleName, deps) {
+      prepareGlobal: function(moduleName, deps, globals, require) {
         // first, we add all the dependency modules to the global
         for (var i = 0; i < deps.length; i++) {
           var moduleGlobal = moduleGlobals[deps[i]];
           if (moduleGlobal)
             for (var m in moduleGlobal)
-              loader.global[m] = moduleGlobal[m];
+              global[m] = moduleGlobal[m];
+        }
+
+        // next we set the globals from the imports object
+        if (globals) {
+          for (var m in globals)
+            global[m] = require(globals[m]);
         }
 
         // now store a complete copy of the global object
         // in order to detect changes
         curGlobalObj = {};
-        ignoredGlobalProps = ['indexedDB', 'sessionStorage', 'localStorage', 'clipboardData', 'frames', 'webkitStorageInfo'];
-        for (var g in loader.global) {
-          if (indexOf.call(ignoredGlobalProps, g) != -1) { continue; }
-          if (!hasOwnProperty || loader.global.hasOwnProperty(g)) {
-            try {
-              curGlobalObj[g] = loader.global[g];
-            } catch (e) {
-              ignoredGlobalProps.push(g);
-            }
-          }
+        
+        for (var g in global) {
+          if (!allowedGlobal(g))
+            continue;
+          curGlobalObj[g] = global[g];
         }
       },
-      retrieveGlobal: function(moduleName, exportName, init) {
+      retrieveGlobal: function(moduleName, exportName) {
         var singleGlobal;
         var multipleExports;
         var exports = {};
 
-        // run init
-        if (init) {
-          var depModules = [];
-          for (var i = 0; i < deps.length; i++)
-            depModules.push(require(deps[i]));
-          singleGlobal = init.apply(loader.global, depModules);
-        }
-
         // check for global changes, creating the globalObject for the module
         // if many globals, then a module object for those is created
         // if one global, then that is the module directly
-        else if (exportName) {
+        if (exportName) {
           var firstPart = exportName.split('.')[0];
-          singleGlobal = eval.call(loader.global, exportName);
-          exports[firstPart] = loader.global[firstPart];
+          singleGlobal = eval.call(global, exportName);
+          exports[firstPart] = global[firstPart];
         }
 
         else {
-          for (var g in loader.global) {
-            if (indexOf.call(ignoredGlobalProps, g) != -1)
+          for (var g in global) {
+            if (!allowedGlobal(g) || global[g] === curGlobalObj[g])
               continue;
-            if ((!hasOwnProperty || loader.global.hasOwnProperty(g)) && g != loader.global && curGlobalObj[g] != loader.global[g]) {
-              exports[g] = loader.global[g];
-              if (singleGlobal) {
-                if (singleGlobal !== loader.global[g])
-                  multipleExports = true;
-              }
-              else if (singleGlobal !== false) {
-                singleGlobal = loader.global[g];
-              }
+            exports[g] = global[g];
+            if (singleGlobal) {
+              if (singleGlobal !== global[g])
+                multipleExports = true;
+            }
+            else if (singleGlobal !== false) {
+              singleGlobal = global[g];
             }
           }
         }
@@ -106,12 +122,29 @@ function global(loader) {
 
     // global is a fallback module format
     if (load.metadata.format == 'global') {
+      var normalizedDeps;
+      var deps = load.metadata.deps;
+      var globals = load.metadata.globals;
+
       load.metadata.execute = function(require, exports, module) {
 
-        loader.get('@@global-helpers').prepareGlobal(module.id, load.metadata.deps);
+        loader.get('@@global-helpers').prepareGlobal(module.id, normalizedDeps, globals, require);
 
         if (exportName)
           load.source += '\nthis["' + exportName + '"] = ' + exportName + ';';
+
+        if (globals) {
+          // create a closure for all the globals so they remain correctly linked
+          // even if they get overritten on the global object
+          var globalNames;
+          for (var m in globals) {
+            if (globalNames)
+              globalNames = ', ' + m;
+            else
+              globalNames = m;
+          }
+          load.source = '(function(' + globalNames + ') {' + load.source + '\n}).call(this, ' + globalNames + ');';
+        }
 
         // disable AMD detection
         var define = loader.global.define;
@@ -125,8 +158,25 @@ function global(loader) {
 
         loader.global.define = define;
 
-        return loader.get('@@global-helpers').retrieveGlobal(module.id, exportName, load.metadata.init);
+        return loader.get('@@global-helpers').retrieveGlobal(module.id, exportName);
       }
+
+      // add dep globals as dependencies if not already
+      if (globals) {
+        for (var m in globals) {
+          if (deps.indexOf(globals[m]) == -1)
+            deps.push(globals[m]);
+        }
+      }
+
+      var normalizePromises = [];
+      for (var i = 0, l = deps.length; i < l; i++)
+        normalizePromises.push(Promise.resolve(loader.normalize(deps[i], load.name, load.address)));
+      
+      return Promise.all(normalizePromises).then(function(_normalizedDeps) {
+        normalizedDeps = _normalizedDeps;
+        return loaderInstantiate.call(loader, load);
+      });
     }
     return loaderInstantiate.call(loader, load);
   }

--- a/lib/extension-meta.js
+++ b/lib/extension-meta.js
@@ -19,7 +19,7 @@
  *   console.log('this is my/module');
  *
  * The benefit of inline meta is that coniguration doesn't need
- * to be known in advanced, which is useful for modularising
+ * to be known in advance, which is useful for modularising
  * configuration and avoiding the need for configuration injection.
  *
  *
@@ -51,6 +51,20 @@ function meta(loader) {
     }
   }
 
+  function setMetaProperty(meta, deepName, value) {
+    var metaNameParts = deepName.split('.');
+    var nextPart;
+    while (metaNameParts.length > 1) {
+      nextPart = metaNameParts.shift();
+      meta = meta[nextPart] = meta[nextPart] || {};
+    } 
+    nextPart = metaNameParts.shift();
+    if (meta[nextPart] instanceof Array)
+      meta[nextPart].push(value);
+    else if (!(nextPart in meta))
+      meta[nextPart] = value;
+  }
+
   var loaderLocate = loader.locate;
   loader.locate = function(load) {
     setConfigMeta(this, load);
@@ -78,11 +92,7 @@ function meta(loader) {
         var metaName = metaString.substr(0, metaString.indexOf(' '));
         if (metaName) {
           var metaValue = metaString.substr(metaName.length + 1, metaString.length - metaName.length - 1);
-
-          if (load.metadata[metaName] instanceof Array)
-            load.metadata[metaName].push(metaValue);
-          else if (!load.metadata[metaName])
-            load.metadata[metaName] = metaValue;
+          setMetaProperty(load.metadata, metaName, metaValue);
         }
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,31 @@ asyncTest('Global script loading that detects as AMD with shim config', function
   }, err);
 });
 
+asyncTest('Global with custom global modules', function() {
+  System.meta['tests/global-global-modules'] = {
+    format: 'global',
+    globals: {
+      '$': './global-global-modules-dep'
+    }
+  };
+  System['import']('tests/global-global-modules').then(function(m) {
+    ok(m.dep == 'global-global-dep');
+    if (typeof window != 'undefined')
+      window.$ = 'changed';
+    else
+      global.$ = 'changed';
+    ok(m.laterDep() == 'global-global-dep')
+    start();
+  }, err);
+});
+
+asyncTest('Global with custom global modules meta', function() {
+  System['import']('tests/global-global-modules-meta').then(function(m) {
+    ok(m == 'global-meta-dep');
+    start();
+  }, err);
+});
+
 if (!ie8)
 asyncTest('Meta should override meta syntax', function() {
   System.meta['tests/meta-override'] = { format: 'es6' };

--- a/test/tests/global-global-modules-dep.js
+++ b/test/tests/global-global-modules-dep.js
@@ -1,0 +1,1 @@
+module.exports = 'global-global-dep';

--- a/test/tests/global-global-modules-meta.js
+++ b/test/tests/global-global-modules-meta.js
@@ -1,0 +1,3 @@
+"format global"
+"globals.G ./global-global-modules-metadep"
+"exports G";

--- a/test/tests/global-global-modules-metadep.js
+++ b/test/tests/global-global-modules-metadep.js
@@ -1,0 +1,1 @@
+module.exports = 'global-meta-dep';

--- a/test/tests/global-global-modules.js
+++ b/test/tests/global-global-modules.js
@@ -1,0 +1,9 @@
+(function(global) {
+
+  global.dep = $;
+
+  global.laterDep = function() {
+    return $;
+  }
+
+})(typeof window == 'undefined' ? global : window);


### PR DESCRIPTION
This creates a new meta configuration option, `globals`, allowing global modules to depend on non-globals. This effectively stops the global format from being a dominating format (since globals can only depend on globals) to a format that plays well just like any other.

The configuration works with:

```javascript
System.meta['global/module'] = {
  globals: {
    '$': 'jquery'
  }
};
```

The above will support multi-versions of the `$` global, and a closure is created so that even if the object is rewritten later, the global module will still have the correct access.

In the above, `jquery` is normalized relative to the global module and can be ES6, AMD, CommonJS etc itself.

The necessary adjustments to meta are also made to allow this same thing to be specified with meta syntax:

```javascript
"format global";
"globals.$ jquery";
```

Whether that is useful is yet to be seen, but it was an easy feature.

As part of this, I've removed the `init` function. If there are still valid use cases for `init` that aren't handled by the above please let me know to reconsider keeping it in.

This resolves https://github.com/systemjs/systemjs/issues/148.