### PR TITLE
parseURI regex update

### DIFF
--- a/lib/polyfill-wrapper-start.js
+++ b/lib/polyfill-wrapper-start.js
@@ -13,7 +13,7 @@ $__global.upgradeSystemLoader = function() {
 
   // Absolute URL parsing, from https://gist.github.com/Yaffle/1088850
   function parseURI(url) {
-    var m = String(url).replace(/^\s+|\s+$/g, '').match(/^([^:\/?#]+:)?(\/\/(?:[^:@]*(?::[^:@]*)?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
+    var m = String(url).replace(/^\s+|\s+$/g, '').match(/^([^:\/?#]+:)?(\/\/(?:[^:@\/]*(?::[^:@\/]*)?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
     // authority = '//' + user + ':' + pass '@' + hostname + ':' port
     return (m ? {
       href     : m[0] || '',


### PR DESCRIPTION
Usernames or passwords should not be allowed to contain slashes.
[Spec ref](https://tools.ietf.org/html/rfc3986#section-3.2.1): userinfo is of type: `unreserved` / `pct-encoded` / `sub-delims` / ":" which doesn't include "`/`".

This breaks systemJS when loading a page with the following URL:
`https://service.domain.com/go?email=jim@jam.com`.
