### PR TITLE
refactor(eval error): modify error message to include its stack trace an...

### DIFF
--- a/lib/polyfill-wrapper-end.js
+++ b/lib/polyfill-wrapper-end.js
@@ -19,7 +19,9 @@ var $__curScript, __eval;
       doEval(source);
     }
     catch(e) {
-      throw 'Error evaluating ' + address;
+      e.message = 'Error evaluating ' + address + '\n' + e.stack;
+
+      throw e;
     }
   };
 


### PR DESCRIPTION
...d throw it.

This change modifies the output from evaluation errors from

Error evaluating /home/brian/dev/day-calendar/jspm_packages/npm/react@0.12.0/addons.js

to

[ReferenceError: Error evaluating /home/brian/dev/day-calendar/jspm_packages/npm/react@0.12.0/addons.js
ReferenceError: navigator is not defined
    at evalmachine.<anonymous>:2:2270
    at Object.<anonymous> (evalmachine.<anonymous>:2:2899)
    at evalmachine.<anonymous>:4:4
    at doEval (/home/brian/dev/day-calendar/node_modules/systemjs/dist/system.src.js:2221:6)
    at __eval (/home/brian/dev/day-calendar/node_modules/systemjs/dist/system.src.js:2138:3)
    at Loader.exec [as __exec](/home/brian/dev/day-calendar/node_modules/systemjs/dist/system.src.js:211:2)
    at load.metadata.execute (/home/brian/dev/day-calendar/node_modules/systemjs/dist/system.src.js:1092:10)
    at linkDynamicModule (/home/brian/dev/day-calendar/node_modules/systemjs/dist/system.src.js:541:29)
    at getModule (/home/brian/dev/day-calendar/node_modules/systemjs/dist/system.src.js:510:3)
    at /home/brian/dev/day-calendar/node_modules/systemjs/dist/system.src.js:545:10]

this allows quicker debugging of the evaluation error.
