### PR TITLE
Combine module deps with metadata deps when registering

### DIFF
--- a/lib/extension-register.js
+++ b/lib/extension-register.js
@@ -469,8 +469,10 @@ function register(loader) {
     var entry;
 
     // first we check if this module has already been defined in the registry
-    if (loader.defined[load.name])
+    if (loader.defined[load.name]) {
       entry = loader.defined[load.name];
+      entry.deps = entry.deps.concat(load.metadata.deps);
+    }
 
     // picked up already by a script injection
     else if (load.metadata.entry)

--- a/test/test.js
+++ b/test/test.js
@@ -618,6 +618,15 @@ asyncTest('AMD -> System.register circular -> ES6', function() {
   }, err);
 });
 
+asyncTest('Metadata dependencies work for named defines', function() {
+  System['import']('tests/meta-deps').then(function(m) {
+    return System['import']('b');
+  }).then(function(m) {
+    ok(m.a === 'a');
+    start();
+  });
+});
+
 if(typeof window !== 'undefined' && window.Worker) {
   asyncTest('Using SystemJS in a Web Worker', function() {
     var worker = new Worker('tests/worker.js');

--- a/test/tests/meta-deps.js
+++ b/test/tests/meta-deps.js
@@ -1,0 +1,13 @@
+System.meta.b = {
+  deps: ['a']
+};
+
+define('a', [], function() {
+  window.MODULEA = 'a';
+});
+
+define('b', [], function() {
+  return {
+    a: window.MODULEA
+  };
+});


### PR DESCRIPTION
This allows metadata deps to become first-class dependencies for all module formats. Fixes #223
