### PR TITLE
Detection for files with byte order mark (BOM)

### DIFF
--- a/lib/extension-amd.js
+++ b/lib/extension-amd.js
@@ -10,7 +10,7 @@ function amd(loader) {
   // AMD Module Format Detection RegEx
   // define([.., .., ..], ...)
   // define(varName); || define(function(require, exports) {}); || define({})
-  var amdRegEx = /(?:^|[^$_a-zA-Z\xA0-\uFFFF.])define\s*\(\s*("[^"]+"\s*,\s*|'[^']+'\s*,\s*)?\s*(\[(\s*(("[^"]+"|'[^']+')\s*,|\/\/.*\r?\n|\/\*(.|\s)*?\*\/))*(\s*("[^"]+"|'[^']+')\s*,?)?(\s*(\/\/.*\r?\n|\/\*(.|\s)*?\*\/))*\s*\]|function\s*|{|[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*\))/;
+  var amdRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF.])define\s*\(\s*("[^"]+"\s*,\s*|'[^']+'\s*,\s*)?\s*(\[(\s*(("[^"]+"|'[^']+')\s*,|\/\/.*\r?\n|\/\*(.|\s)*?\*\/))*(\s*("[^"]+"|'[^']+')\s*,?)?(\s*(\/\/.*\r?\n|\/\*(.|\s)*?\*\/))*\s*\]|function\s*|{|[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*\))/;
   var commentRegEx = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
 
   var cjsRequirePre = "(?:^|[^$_a-zA-Z\\xA0-\\uFFFF.])";

--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -5,9 +5,9 @@ function cjs(loader) {
 
   // CJS Module Format
   // require('...') || exports[''] = ... || exports.asd = ... || module.exports = ...
-  var cjsExportsRegEx = /(?:^|[^$_a-zA-Z\xA0-\uFFFF.]|module\.)(exports\s*\[['"]|\exports\s*\.)|(?:^|[^$_a-zA-Z\xA0-\uFFFF.])module\.exports\s*\=/;
+  var cjsExportsRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF.]|module\.)(exports\s*\[['"]|\exports\s*\.)|(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF.])module\.exports\s*\=/;
   // RegEx adjusted from https://github.com/jbrantly/yabble/blob/master/lib/yabble.js#L339
-  var cjsRequireRegEx = /(?:^|[^$_a-zA-Z\xA0-\uFFFF."'])require\s*\(\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')\s*\)/g;
+  var cjsRequireRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF."'])require\s*\(\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')\s*\)/g;
   var commentRegEx = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
 
   function getCJSDeps(source) {

--- a/test/test.js
+++ b/test/test.js
@@ -224,6 +224,13 @@ asyncTest('AMD detection test with comments', function() {
   }, err);
 });
 
+asyncTest('AMD detection test with byte order mark (BOM)', function() {
+  System['import']('tests/amd-module-bom').then(function(m) {
+    ok(m.amd);
+    start();
+  }, err);
+});
+
 System.bundles['tests/amd-bundle'] = ['bundle-1', 'bundle-2'];
 asyncTest('Loading an AMD bundle', function() {
   System['import']('bundle-1').then(function(m) {
@@ -273,14 +280,28 @@ asyncTest('Loading a CommonJS module with this', function() {
 
 asyncTest('CommonJS setting module.exports', function() {
   System['import']('tests/cjs-exports').then(function(m) {
-    ok(m.e = 'export');
+    ok(m.e == 'export');
     start();
   }, err);
 });
 
-asyncTest('CommonJS detection variattion', function() {
+asyncTest('CommonJS detection variation', function() {
   System['import']('tests/commonjs-variation').then(function(m) {
     ok(m.e === System.get('@empty'));
+    start();
+  }, err);
+});
+
+asyncTest('CommonJS detection test with byte order mark (BOM)', function() {
+  System['import']('tests/cjs-exports-bom').then(function(m) {
+    ok(m.foo == 'bar');
+    start();
+  }, err);
+});
+
+asyncTest('CommonJS module detection test with byte order mark (BOM)', function() {
+  System['import']('tests/cjs-module-bom').then(function(m) {
+    ok(m.foo == 'bar');
     start();
   }, err);
 });

--- a/test/tests/amd-module-bom.js
+++ b/test/tests/amd-module-bom.js
@@ -1,0 +1,4 @@
+﻿define([], function () {
+    // file starts with a byte order mark (BOM)
+    return { amd: true };
+});

--- a/test/tests/cjs-exports-bom.js
+++ b/test/tests/cjs-exports-bom.js
@@ -1,0 +1,1 @@
+﻿exports.foo = "bar";

--- a/test/tests/cjs-module-bom.js
+++ b/test/tests/cjs-module-bom.js
@@ -1,0 +1,1 @@
+﻿module.exports.foo = "bar";


### PR DESCRIPTION
If files begin with a BOM (U+FEFF) the AMD and CommonJS detection will fail. I noticed this when using the SystemJS builder: https://github.com/systemjs/builder/issues/25
