### PR TITLE
dont assume require is defined when setting up cjs loader

### DIFF
--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -27,7 +27,8 @@ function cjs(loader) {
     return deps;
   }
 
-  var nodeRequire = require;
+  // do not assume that require exists
+  var nodeRequire = typeof require !== 'undefined' ? require : null;
 
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
@@ -59,7 +60,7 @@ function cjs(loader) {
           nodeRequire: nodeRequire
         };
 
-        var source = '(function(global, exports, module, require, __filename, __dirname, nodeRequire) { ' + load.source 
+        var source = '(function(global, exports, module, require, __filename, __dirname, nodeRequire) { ' + load.source
           + '\n}).call(_g.exports, _g.global, _g.exports, _g.module, _g.require, _g.__filename, _g.__dirname, _g.nodeRequire);';
 
         // disable AMD detection


### PR DESCRIPTION
Was running into an `require is not defined` error when trying to use [this](https://github.com/systemjs/systemjs/blob/master/dist/system.js). This seems to be a sensible fix and all the tests pass.
