### PR TITLE
Auto load traceur runtime

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.10.1",
   "main": "dist/system.js",
   "dependencies": {
-    "es6-module-loader": "~0.10.0"
+    "es6-module-loader": "~0.10.0",
+    "traceur-runtime": "~0.0.79"
   },
   "devDependencies": {
     "qunit": "~1.12.0"

--- a/lib/extension-core.js
+++ b/lib/extension-core.js
@@ -101,11 +101,13 @@ function core(loader) {
   // good enough ES6 detection regex - format detections not designed to be accurate, but to handle the 99% use case
   var es6RegEx = /(^\s*|[}\);\n]\s*)(import\s+(['"]|(\*\s+as\s+)?[^"'\(\)\n;]+\s+from\s+['"]|\{)|export\s+\*\s+from\s+["']|export\s+(\{|default|function|class|var|const|let))/;
 
+  var traceurRuntimeRegEx = /\$traceurRuntime/;
+
   var loaderTranslate = loader.translate;
   loader.translate = function(load) {
     var loader = this;
 
-    if (load.name == '@traceur')
+    if (load.name == '@traceur' || load.name == '@traceur-runtime')
       return loaderTranslate.call(loader, load);
 
     // detect ES6
@@ -120,6 +122,13 @@ function core(loader) {
       }
     }
 
+    // dynamicallly load Traceur runtime if necessary
+    if (!loader.global.$traceurRuntime && load.source.match(traceurRuntimeRegEx)) {
+      return loader['import']('@traceur-runtime').then(function() {
+        return loaderTranslate.call(loader, load);
+      });
+    }
+
     return loaderTranslate.call(loader, load);
   }
 
@@ -127,7 +136,7 @@ function core(loader) {
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
     var loader = this;
-    if (load.name == '@traceur') {
+    if (load.name == '@traceur' || load.name == '@traceur-runtime') {
       loader.__exec(load);
       return {
         deps: [],

--- a/lib/polyfill-wrapper-end.js
+++ b/lib/polyfill-wrapper-end.js
@@ -4,6 +4,8 @@
         ? $__curScript.src.substr(0, $__curScript.src.lastIndexOf('/') + 1) 
         : System.baseURL + (System.baseURL.lastIndexOf('/') == System.baseURL.length - 1 ? '' : '/')
         ) + 'traceur.js';
+  if (!System.paths['@traceur-runtime'])
+    System.paths['@traceur-runtime'] = $__curScript && $__curScript.getAttribute('data-traceur-runtime-src') || System.paths['@traceur'].replace(/\.js$/, '-runtime.js');
 };
 
 var $__curScript, __eval;

--- a/test/test-runtime.html
+++ b/test/test-runtime.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+  </head>
+  <body>
+
+    <h1 id="qunit-header">SystemJS Test Suite</h1>
+
+    <h2 id="qunit-banner"></h2>
+    <div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+    <div id="qunit-test-area"></div>
+
+    <!-- <script src="../bower_components/traceur/traceur.js"></script> -->
+    <script src="../bower_components/es6-module-loader/dist/es6-module-loader.js"></script>
+    <script src="../dist/system.js" data-traceur-runtime-src="../bower_components/traceur-runtime/traceur-runtime.js" type="text/javascript"></script>
+
+    <script src="../bower_components/qunit/qunit/qunit.js"></script>
+
+    <script>
+      QUnit.config.testTimeout = 2000;
+
+      QUnit.module("SystemJS Runtime");
+
+      function err(e) {
+        setTimeout(function() {
+          throw e;
+          start();
+        });  
+      }
+
+      asyncTest('Dynamicall loading modules with Traceur runtime', function() {
+        System['import']('tests/with-runtime').then(function(m) {
+          ok(m.c);
+          start();
+        }, err);
+      });
+
+    </script>
+  </body>
+</html>

--- a/test/tests/with-runtime.js
+++ b/test/tests/with-runtime.js
@@ -1,0 +1,17 @@
+System.register([], function($__export) {
+  "use strict";
+  var __moduleName = "test";
+  function require(path) {
+    return $traceurRuntime.require("test", path);
+  }
+  var c;
+  return {
+    setters: [],
+    execute: function() {
+      c = $__export("c", (function() {
+        var c = function c() {};
+        return ($traceurRuntime.createClass)(c, {}, {});
+      }()));
+    }
+  };
+});


### PR DESCRIPTION
This detects `$traceurRuntime` use in source and automatically loads Traceur runtime just like we automatically load Traceur when ES6 is used.

Fixes https://github.com/systemjs/systemjs/issues/258.
