### PR TITLE
Correct versions object reference

### DIFF
--- a/lib/extension-versions.js
+++ b/lib/extension-versions.js
@@ -241,7 +241,7 @@ function versions(loader) {
   loader.normalize = function(name, parentName, parentAddress) {
     if (!loader.versions)
       loader.versions = {};
-    var packageVersions = this.versions;
+    var packageVersions = loader.versions;
 
     // strip the version before applying map config
     var stripVersion, stripSubPathLength;


### PR DESCRIPTION
When using systemjs-builder with a jspm-installed npm module, I was receiving the following error:

```
$ gulp build
[09:26:03] Using gulpfile ~/Repos/test/systemjs/gulpfile.js
[09:26:03] Starting 'build'...
[09:26:05] 'build' errored after 2.06 s
[09:26:05] TypeError: Error loading "scripts/main" at file:/Users/.../Repos/test/systemjs/src/assets/scripts/main.js
Cannot read property 'npm:mout' of undefined
    at $__global.upgradeSystemLoader.loader.normalize (/Users/.../Repos/test/systemjs/node_modules/systemjs-builder/node_modules/systemjs/dist/system.src.js:2033:33)
    at System.register.then (/Users/.../Repos/test/systemjs/node_modules/systemjs-builder/node_modules/traceur/bin/traceur.js:1742:100)
    at promiseHandle (/Users/.../Repos/test/systemjs/node_modules/systemjs-builder/node_modules/traceur/bin/traceur.js:1829:20)
    at /Users/.../Repos/test/systemjs/node_modules/systemjs-builder/node_modules/traceur/bin/traceur.js:1823:9
    at flush (/Users/.../Repos/test/systemjs/node_modules/systemjs-builder/node_modules/traceur/bin/traceur.js:1624:7)
    at process._tickCallback (node.js:419:13)
```

When I debugged the issue with node-inspector, I found that `this` was referring to the global object. Changing `this.versions` to match `loader.versions` on the previous line corrected the issue and the build ran clean.
