### PR TITLE
fix: Loader referenced to global object

### DIFF
--- a/lib/extension-amd.js
+++ b/lib/extension-amd.js
@@ -50,9 +50,6 @@ function amd(loader) {
     To copy RequireJS, set window.require = window.requirejs = loader.amdRequire
   */
   function require(names, callback, errback, referer) {
-    // 'this' is bound to the loader
-    var loader = this;
-
     // in amd, first arg can be a config object... we just ignore
     if (typeof names == 'object' && !(names instanceof Array))
       return require.apply(null, Array.prototype.splice.call(arguments, 1, arguments.length - 1));
@@ -248,15 +245,13 @@ function amd(loader) {
   if (loader.scriptLoader) {
     var loaderFetch = loader.fetch;
     loader.fetch = function(load) {
-      createDefine(this);
-      return loaderFetch.call(this, load);
+      createDefine(loader);
+      return loaderFetch.call(loader, load);
     }
   }
 
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
-    var loader = this;
-
     if (load.metadata.format == 'amd' || !load.metadata.format && load.source.match(amdRegEx)) {
       load.metadata.format = 'amd';
 

--- a/lib/extension-bundles.js
+++ b/lib/extension-bundles.js
@@ -26,9 +26,8 @@ function bundles(loader) {
 
   var loaderFetch = loader.fetch;
   loader.fetch = function(load) {
-    var loader = this;
     if (loader.trace)
-      return loaderFetch.call(this, load);
+      return loaderFetch.call(loader, load);
     if (!loader.bundles)
       loader.bundles = {};
 
@@ -53,6 +52,6 @@ function bundles(loader) {
         return '';
       });
     }
-    return loaderFetch.call(this, load);
+    return loaderFetch.call(loader, load);
   }
 }

--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -29,7 +29,6 @@ function cjs(loader) {
 
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
-
     if (!load.metadata.format) {
       cjsExportsRegEx.lastIndex = 0;
       cjsRequireRegEx.lastIndex = 0;
@@ -79,6 +78,6 @@ function cjs(loader) {
       }
     }
 
-    return loaderInstantiate.call(this, load);
+    return loaderInstantiate.call(loader, load);
   };
 }

--- a/lib/extension-core.js
+++ b/lib/extension-core.js
@@ -21,7 +21,7 @@ function core(loader) {
   */
   var loaderImport = loader['import'];
   loader['import'] = function(name, options) {
-    return loaderImport.call(this, name, options).then(function(module) {
+    return loaderImport.call(loader, name, options).then(function(module) {
       return module.__useDefault ? module['default'] : module;
     });
   }
@@ -56,12 +56,12 @@ function core(loader) {
     for (var c in cfg) {
       var v = cfg[c];
       if (typeof v == 'object' && !(v instanceof Array)) {
-        this[c] = this[c] || {};
+        loader[c] = loader[c] || {};
         for (var p in v)
-          this[c][p] = v[p];
+          loader[c][p] = v[p];
       }
       else
-        this[c] = v;
+        loader[c] = v;
     }
   }
 
@@ -86,15 +86,15 @@ function core(loader) {
   var loaderLocate = loader.locate;
   var normalizedBaseURL;
   loader.locate = function(load) {
-    if (this.baseURL != normalizedBaseURL) {
-      normalizedBaseURL = toAbsoluteURL(baseURI, this.baseURL);
+    if (loader.baseURL != normalizedBaseURL) {
+      normalizedBaseURL = toAbsoluteURL(baseURI, loader.baseURL);
 
       if (normalizedBaseURL.substr(normalizedBaseURL.length - 1, 1) != '/')
         normalizedBaseURL += '/';
-      this.baseURL = normalizedBaseURL;
+      loader.baseURL = normalizedBaseURL;
     }
 
-    return Promise.resolve(loaderLocate.call(this, load));
+    return Promise.resolve(loaderLocate.call(loader, load));
   }
 
   // Traceur conveniences
@@ -105,8 +105,6 @@ function core(loader) {
 
   var loaderTranslate = loader.translate;
   loader.translate = function(load) {
-    var loader = this;
-
     if (load.name == '@traceur' || load.name == '@traceur-runtime')
       return loaderTranslate.call(loader, load);
 
@@ -135,7 +133,6 @@ function core(loader) {
   // always load Traceur as a global
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
-    var loader = this;
     if (load.name == '@traceur' || load.name == '@traceur-runtime') {
       loader.__exec(load);
       return {

--- a/lib/extension-depCache.js
+++ b/lib/extension-depCache.js
@@ -24,8 +24,6 @@ function depCache(loader) {
 
   loaderLocate = loader.locate;
   loader.locate = function(load) {
-    var loader = this;
-
     if (!loader.depCache)
       loader.depCache = {};
 

--- a/lib/extension-global.js
+++ b/lib/extension-global.js
@@ -106,8 +106,6 @@ function global(loader) {
 
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
-    var loader = this;
-
     createHelpers(loader);
 
     var exportName = load.metadata.exports;

--- a/lib/extension-map.js
+++ b/lib/extension-map.js
@@ -121,7 +121,6 @@ function map(loader) {
 
   var loaderNormalize = loader.normalize;
   loader.normalize = function(name, parentName, parentAddress) {
-    var loader = this;
     if (!loader.map)
       loader.map = {};
 

--- a/lib/extension-meta.js
+++ b/lib/extension-meta.js
@@ -43,7 +43,7 @@ function meta(loader) {
 
   loader.meta = {};
 
-  function setConfigMeta(loader, load) {
+  function setConfigMeta(load) {
     var meta = loader.meta && loader.meta[load.name];
     if (meta) {
       for (var p in meta)
@@ -53,8 +53,8 @@ function meta(loader) {
 
   var loaderLocate = loader.locate;
   loader.locate = function(load) {
-    setConfigMeta(this, load);
-    return loaderLocate.call(this, load);
+    setConfigMeta(load);
+    return loaderLocate.call(loader, load);
   }
 
   var loaderTranslate = loader.translate;
@@ -87,8 +87,8 @@ function meta(loader) {
       }
     }
     // config meta overrides
-    setConfigMeta(this, load);
+    setConfigMeta(load);
     
-    return loaderTranslate.call(this, load);
+    return loaderTranslate.call(loader, load);
   }
 }

--- a/lib/extension-plugins.js
+++ b/lib/extension-plugins.js
@@ -12,7 +12,6 @@ function plugins(loader) {
 
   var loaderNormalize = loader.normalize;
   loader.normalize = function(name, parentName, parentAddress) {
-    var loader = this;
     // if parent is a plugin, normalize against the parent plugin argument only
     var parentPluginIndex;
     if (parentName && (parentPluginIndex = parentName.indexOf('!')) != -1)
@@ -49,13 +48,11 @@ function plugins(loader) {
 
   var loaderLocate = loader.locate;
   loader.locate = function(load) {
-    var loader = this;
-
     var name = load.name;
 
     // only fetch the plugin itself if this name isn't defined
-    if (this.defined && this.defined[name])
-      return loaderLocate.call(this, load);
+    if (loader.defined && loader.defined[name])
+      return loaderLocate.call(loader, load);
 
     // plugin
     var pluginIndex = name.lastIndexOf('!');
@@ -97,12 +94,11 @@ function plugins(loader) {
       });
     }
 
-    return loaderLocate.call(this, load);
+    return loaderLocate.call(loader, load);
   }
 
   var loaderFetch = loader.fetch;
   loader.fetch = function(load) {
-    var loader = this;
     if (load.metadata.build === false)
       return '';
     else if (load.metadata.plugin && load.metadata.plugin.fetch && !load.metadata.pluginFetchCalled) {
@@ -115,7 +111,6 @@ function plugins(loader) {
 
   var loaderTranslate = loader.translate;
   loader.translate = function(load) {
-    var loader = this;
     if (load.metadata.plugin && load.metadata.plugin.translate)
       return Promise.resolve(load.metadata.plugin.translate.call(loader, load)).then(function(result) {
         if (result)
@@ -128,7 +123,6 @@ function plugins(loader) {
 
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
-    var loader = this;
     if (load.metadata.plugin && load.metadata.plugin.instantiate)
       return Promise.resolve(load.metadata.plugin.instantiate.call(loader, load)).then(function(result) {
         load.metadata.format = 'defined';

--- a/lib/extension-register.js
+++ b/lib/extension-register.js
@@ -26,7 +26,6 @@ function register(loader) {
   // main feature is source maps support handling
   var curSystem;
   function exec(load) {
-    var loader = this;
     if (load.name == '@traceur') {
       curSystem = System;
     }
@@ -423,7 +422,6 @@ function register(loader) {
 
   var loaderFetch = loader.fetch;
   loader.fetch = function(load) {
-    var loader = this;
     defineRegister(loader);
     if (loader.defined[load.name]) {
       load.metadata.format = 'defined';
@@ -437,14 +435,14 @@ function register(loader) {
 
   var loaderTranslate = loader.translate;
   loader.translate = function(load) {
-    this.register = register;
+    loader.register = register;
 
-    this.__exec = exec;
+    loader.__exec = exec;
 
     load.metadata.deps = load.metadata.deps || [];
 
     // we run the meta detection here (register is after meta)
-    return Promise.resolve(loaderTranslate.call(this, load)).then(function(source) {
+    return Promise.resolve(loaderTranslate.call(loader, load)).then(function(source) {
       
       // dont run format detection for globals shimmed
       // ideally this should be in the global extension, but there is
@@ -462,8 +460,6 @@ function register(loader) {
 
   var loaderInstantiate = loader.instantiate;
   loader.instantiate = function(load) {
-    var loader = this;
-
     var entry;
 
     // first we check if this module has already been defined in the registry
@@ -525,7 +521,7 @@ function register(loader) {
 
     // no entry -> treat as ES6
     else
-      return loaderInstantiate.call(this, load);
+      return loaderInstantiate.call(loader, load);
 
     entry.deps = dedupe(entry.deps);
     entry.name = load.name;

--- a/lib/extension-versions.js
+++ b/lib/extension-versions.js
@@ -239,9 +239,9 @@ function versions(loader) {
   var loaderNormalize = loader.normalize;
   // NOW use modified match algorithm if possible
   loader.normalize = function(name, parentName, parentAddress) {
-    if (!this.versions)
-      this.versions = {};
-    var packageVersions = this.versions;
+    if (!loader.versions)
+      loader.versions = {};
+    var packageVersions = loader.versions;
 
     // strip the version before applying map config
     var stripVersion, stripSubPathLength;
@@ -255,7 +255,7 @@ function versions(loader) {
     }
 
     // run all other normalizers first
-    return Promise.resolve(loaderNormalize.call(this, name, parentName, parentAddress)).then(function(normalized) {
+    return Promise.resolve(loaderNormalize.call(loader, name, parentName, parentAddress)).then(function(normalized) {
       
       var index = normalized.indexOf('@');
 


### PR DESCRIPTION
When requiring in Require.js style, `this` pointed to global object instead of a loader.

It happened after following RequireJS shim:

```
window.require = window.requirejs = System.amdRequire;
```

This commit fixes whole class of such issues.

Basically I avoid using "this" as much as possible.
