### PR TITLE
Adds tests showing a problem with connected trees and es modules in the middle

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -674,6 +674,13 @@ asyncTest('Loading an AMD module that requires another works', function() {
   });
 });
 
+asyncTest('Loading a connected tree that connects ES and CJS modules', function(){
+	System['import']('tests/connected-tree/a').then(function(a){
+		ok(a.name === "a");
+		start();
+	});
+});
+
 if(typeof window !== 'undefined' && window.Worker) {
   asyncTest('Using SystemJS in a Web Worker', function() {
     var worker = new Worker('tests/worker.js');

--- a/test/tests/connected-tree/a.js
+++ b/test/tests/connected-tree/a.js
@@ -1,0 +1,9 @@
+// a.js 
+var c = require("./c");
+var b = require('./b');
+
+module.exports = {
+	name: "a",
+	b: b,
+	c: c
+};

--- a/test/tests/connected-tree/b.js
+++ b/test/tests/connected-tree/b.js
@@ -1,0 +1,6 @@
+import c from "./c";
+
+export default {
+	name: "b",
+	c: c
+};

--- a/test/tests/connected-tree/c.js
+++ b/test/tests/connected-tree/c.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: "c"
+};


### PR DESCRIPTION
Background of the problem: https://groups.google.com/forum/#!topic/systemjs/ecPVGbX0MVQ

 I have something like the following: 
```js
  // a.js 
  require('./b'); 
  require('./c'); 

  // b.js 
  import from "./c" 

  // c.js 
  require('d'); 
```

And this breaks.