### PR TITLE
Avoid parsing require("dep") inside strings in CJS

### DIFF
--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -9,6 +9,7 @@ function cjs(loader) {
   // RegEx adjusted from https://github.com/jbrantly/yabble/blob/master/lib/yabble.js#L339
   var cjsRequireRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF."'])require\s*\(\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')\s*\)/g;
   var commentRegEx = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
+  var otherStringsRegEx = /(require\s*\(\s*)?(?:"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')/g;
 
   function getCJSDeps(source) {
     cjsRequireRegEx.lastIndex = 0;
@@ -18,6 +19,13 @@ function cjs(loader) {
     // remove comments from the source first, if not minified
     if (source.length / source.split('\n').length < 200)
       source = source.replace(commentRegEx, '');
+
+    // remove strings unrelated to require() calls from the source first
+    // to avoid parsing a require() inside a string
+    // Note: simulating lookbehind by checking for a prefix match
+    source = source.replace(otherStringsRegEx, function(wholeMatch, reqPrefix) {
+      return reqPrefix ? wholeMatch : '';
+    });
 
     var match;
 

--- a/test/test.js
+++ b/test/test.js
@@ -313,6 +313,8 @@ asyncTest('CommonJS require variations', function() {
     ok(m.d1 == 'd');
     ok(m.d2 == 'd');
     ok(m.d3 == "require('not a dep')");
+    ok(m.d4 == "text require('still not a dep') text");
+    ok(m.d5 == 'text \'quote\' require("yet still not a dep")');
     start();
   }, err);
 });

--- a/test/tests/commonjs-requires.js
+++ b/test/tests/commonjs-requires.js
@@ -6,3 +6,7 @@ exports.d2 = (require
 ("./commonjs-d"));
 
 exports.d3 = "require('not a dep')";
+
+exports.d4 = "text require('still not a dep') text";
+
+exports.d5 = 'text \'quote\' require("yet still not a dep")';


### PR DESCRIPTION
Fixes https://github.com/systemjs/systemjs/issues/311

Bit of a tedious job as I couldn't find an elegant way to update `cjsRequireRegEx` to check whether/reject if the match is within a string. The solution I arrived to is to strip all strings from the source if they are not prefixed by (`require(`). In the absence of lookbehind in JS regex, I have to fallback to an explicit prefix check in the replace function.

I've not restricted this to non-minimised files, since I expect the issue would arise even in minimised files.

The only minor worry is whether this operation is too expensive, but hard to judge without a bit of a performance testing harness.