### PR TITLE
Test for shared dependency bundle bug

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ function err(e) {
     else
       throw e;
     start();
-  });  
+  });
 }
 
 var ie8 = typeof navigator != 'undefined' && navigator.appVersion && navigator.appVersion.indexOf('MSIE 8') != -1;
@@ -689,6 +689,18 @@ asyncTest('Loading a connected tree that connects ES and CJS modules', function(
 		ok(a.name === "a");
 		start();
 	});
+});
+
+asyncTest('Loading two bundles that have a shared dependency', function() {
+  System.bundles["tests/shared-dep-bundles/a"] = ["lib/shared-dep", "lib/a"];
+  System.bundles["tests/shared-dep-bundles/b"] = ["lib/shared-dep", "lib/b"];
+  expect(0);
+  System['import']('lib/a').then(function() {
+    System['import']('lib/b').then(function() {
+      //If it gets here it's fine
+      start();
+    }).catch(function(err) { console.log(err.stack); });
+  });
 });
 
 if(typeof window !== 'undefined' && window.Worker) {

--- a/test/tests/shared-dep-bundles/a.js
+++ b/test/tests/shared-dep-bundles/a.js
@@ -1,0 +1,33 @@
+"format register";
+
+System.register("lib/shared-dep", [], function($__export) {
+  "use strict";
+  var __moduleName = "lib/shared-dep";
+  function shared() {}
+  $__export("default", shared);
+  return {
+    setters: [],
+    execute: function() {
+      ;
+    }
+  };
+});
+
+
+
+System.register("lib/a", ["./shared-dep"], function($__export) {
+  "use strict";
+  var __moduleName = "lib/a";
+  var shared;
+  return {
+    setters: [function(m) {
+      shared = m.default;
+    }],
+    execute: function() {
+    }
+  };
+});
+
+
+
+//# sourceMappingURL=a.js.map

--- a/test/tests/shared-dep-bundles/b.js
+++ b/test/tests/shared-dep-bundles/b.js
@@ -1,0 +1,33 @@
+"format register";
+
+System.register("lib/shared-dep", [], function($__export) {
+  "use strict";
+  var __moduleName = "lib/shared-dep";
+  function shared() {}
+  $__export("default", shared);
+  return {
+    setters: [],
+    execute: function() {
+      ;
+    }
+  };
+});
+
+
+
+System.register("lib/b", ["./shared-dep"], function($__export) {
+  "use strict";
+  var __moduleName = "lib/b";
+  var shared;
+  return {
+    setters: [function(m) {
+      shared = m.default;
+    }],
+    execute: function() {
+    }
+  };
+});
+
+
+
+//# sourceMappingURL=b.js.map


### PR DESCRIPTION
A test that currently breaks - given two bundles `a.js` and `b.js` with a shared dependency, System.import() currently fails depending on the order in which the bundles are imported.