### PR TITLE
String removal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "system.js",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "main": "dist/system.js",
   "dependencies": {
     "es6-module-loader": "~0.12.0",

--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -9,6 +9,7 @@ function cjs(loader) {
   // RegEx adjusted from https://github.com/jbrantly/yabble/blob/master/lib/yabble.js#L339
   var cjsRequireRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF."'])require\s*\(\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')\s*\)/g;
   var commentRegEx = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
+  var otherStringsRegEx = /(require\s*\(\s*)?(?:"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')/g;
 
   function getCJSDeps(source) {
     cjsRequireRegEx.lastIndex = 0;
@@ -18,6 +19,13 @@ function cjs(loader) {
     // remove comments from the source first, if not minified
     if (source.length / source.split('\n').length < 200)
       source = source.replace(commentRegEx, '');
+
+    // remove strings unrelated to require() calls from the source first
+    // to avoid parsing a require() inside a string
+    // Note: simulating lookbehind by checking for a prefix match
+    source = source.replace(otherStringsRegEx, function(wholeMatch, reqPrefix) {
+      return reqPrefix ? wholeMatch : '';
+    });
 
     var match;
 

--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -9,7 +9,7 @@ function cjs(loader) {
   // RegEx adjusted from https://github.com/jbrantly/yabble/blob/master/lib/yabble.js#L339
   var cjsRequireRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF."'])require\s*\(\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')\s*\)/g;
   var commentRegEx = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
-  var otherStringsRegEx = /(require\s*\(\s*)?(?:"[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')/g;
+  var otherStringsRegEx = /(require\s*\(\s*)?(?:"[^"\\\n\r]*(?:\\.[^"\\\n\r]*)*"|'[^'\\\n\r]*(?:\\.[^'\\\n\r]*)*')/g;
 
   function getCJSDeps(source) {
     cjsRequireRegEx.lastIndex = 0;

--- a/lib/extension-cjs.js
+++ b/lib/extension-cjs.js
@@ -16,16 +16,17 @@ function cjs(loader) {
 
     var deps = [];
 
-    // remove comments from the source first, if not minified
-    if (source.length / source.split('\n').length < 200)
-      source = source.replace(commentRegEx, '');
+    // remove comments and strings from the source first, if not minified
+    if (source.length / source.split('\n').length < 200) {
+      // remove strings unrelated to require() calls from the source first
+      // to avoid parsing a require() inside a string
+      // Note: simulating lookbehind by checking for a prefix match
+      source = source.replace(otherStringsRegEx, function(wholeMatch, reqPrefix) {
+        return reqPrefix ? wholeMatch : '';
+      });
 
-    // remove strings unrelated to require() calls from the source first
-    // to avoid parsing a require() inside a string
-    // Note: simulating lookbehind by checking for a prefix match
-    source = source.replace(otherStringsRegEx, function(wholeMatch, reqPrefix) {
-      return reqPrefix ? wholeMatch : '';
-    });
+      source = source.replace(commentRegEx, '');
+    }
 
     var match;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemjs",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "System loader extension for flexible AMD & CommonJS support",
   "main": "dist/system.src.js",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -311,8 +311,8 @@ asyncTest('CommonJS require variations', function() {
     ok(m.d1 == 'd');
     ok(m.d2 == 'd');
     ok(m.d3 == "require('not a dep')");
-    // ok(m.d4 == "text require('still not a dep') text");
-    // ok(m.d5 == 'text \'quote\' require("yet still not a dep")');
+    ok(m.d4 == "text require('still not a dep') text");
+    ok(m.d5 == 'text \'quote\' require("yet still not a dep")');
     start();
   }, err);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -313,6 +313,7 @@ asyncTest('CommonJS require variations', function() {
     ok(m.d3 == "require('not a dep')");
     ok(m.d4 == "text require('still not a dep') text");
     ok(m.d5 == 'text \'quote\' require("yet still not a dep")');
+    ok(m.d6 == 'd6');
     start();
   }, err);
 });

--- a/test/tests/commonjs-d2.js
+++ b/test/tests/commonjs-d2.js
@@ -1,0 +1,1 @@
+module.exports = 'd6';

--- a/test/tests/commonjs-requires.js
+++ b/test/tests/commonjs-requires.js
@@ -7,6 +7,6 @@ exports.d2 = (require
 
 exports.d3 = "require('not a dep')";
 
-// exports.d4 = "text require('still not a dep') text";
+exports.d4 = "text require('still not a dep') text";
 
-// exports.d5 = 'text \'quote\' require("yet still not a dep")';
+exports.d5 = 'text \'quote\' require("yet still not a dep")';

--- a/test/tests/commonjs-requires.js
+++ b/test/tests/commonjs-requires.js
@@ -10,3 +10,9 @@ exports.d3 = "require('not a dep')";
 exports.d4 = "text require('still not a dep') text";
 
 exports.d5 = 'text \'quote\' require("yet still not a dep")';
+
+var regexWithString = /asdfasdf " /;
+
+exports.d6 = require('./commonjs-d2');
+
+var regexClose = /asdf " /;


### PR DESCRIPTION
@theefer I had another crack at your previous work and I think this resolves things!

Basically, to avoid string characters in regexs breaking things, we just needed to limit the string capture to be single-line only.

@dougwilson thanks for the tip on this one.