### PR TITLE
Fix plugin extension returning wrong address when .locate()

### DIFF
--- a/lib/extension-plugins.js
+++ b/lib/extension-plugins.js
@@ -94,7 +94,7 @@ function plugins(loader) {
         else
           return Promise.resolve(loader.locate(load))
           .then(function(address) {
-            return address.substr(0, address.length - 3);
+            return address.replace(/\.js$/, '');
           });
       });
     }


### PR DESCRIPTION
If a module is configured with path not ending in '.js', the old behaviour will incorrectly remove the last 3 chars from the address.