### PR TITLE
Test showing a bug with bundles that use System.define.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -729,6 +729,18 @@ asyncTest("System.clone", function() {
   });
 });
 
+asyncTest("A module in one bundle can load a System.define module in another bundle", function(){
+	System.bundles['tests/split-bundle-define/master-bundle'] = ['master'];
+	System.bundles['tests/split-bundle-define/slave-bundle'] = ['slave'];
+	System.meta.slave = {format: "global", exports: "slave"};
+	
+	System['import']("master").then(function(master){
+		ok(master.name === "master", "master name is right");
+		ok(master.slave.name === "slave", "slave name is right");
+		start();
+	});
+});
+
 if(typeof window !== 'undefined' && window.Worker) {
   asyncTest('Using SystemJS in a Web Worker', function() {
     var worker = new Worker('tests/worker.js');

--- a/test/tests/split-bundle-define/master-bundle.js
+++ b/test/tests/split-bundle-define/master-bundle.js
@@ -1,0 +1,3 @@
+define('master',['slave'], function(slave){
+	return {name: "master", slave: slave};
+});

--- a/test/tests/split-bundle-define/slave-bundle.js
+++ b/test/tests/split-bundle-define/slave-bundle.js
@@ -1,0 +1,1 @@
+System.define("slave","window.slave = {name: 'slave'};",{"metadata": {"format": "global"}});


### PR DESCRIPTION
I have two bundles.  The first "master-bundle" bundle looks like:

```js
define('master',['slave'], function(slave){
	return {name: "master", slave: slave};
});
```

The second "slave-bundle" bundle looks like:

```js
System.define("slave","window.slave = {name: 'slave'};",{"metadata": {"format": "global"}});
```

The "slave" module format's meta format is set to "global" and it exports "slave":

```js
System.meta.slave = {format: "global", exports: "slave"};
```

The `slave` module will not be imported correctly.  It's source will be empty, except for the "global" format's insertion of `this["slave"] = slave`.  An error will happen like "slave is not defined".

The problem seems to be that `define('master',['slave'] ` creates a load for "slave" on `loader.loads`.  This supersedes the load that the `System.define -> asyncStartLoadPartwayThrough` creates with the appropriate source.

I think the problem is likely in ES6ML.  I'm guessing that `asyncStartLoadPartwayThrough` should not be using the existingLoad in certain cases.  This is likely a problem with ES6ML, but I am not sure how to expose it without bundles.




