### PR TITLE
Assigning some values breaks in IE8

### DIFF
--- a/dist/system.src.js
+++ b/dist/system.src.js
@@ -980,7 +980,9 @@ function global(loader) {
           var moduleGlobal = moduleGlobals[deps[i]];
           if (moduleGlobal)
             for (var m in moduleGlobal)
-              loader.global[m] = moduleGlobal[m];
+				try{ 
+				  loader.global[m] = moduleGlobal[m];
+				} catch(e){};
         }
 
         // now store a complete copy of the global object


### PR DESCRIPTION
Libraries like MooTools fill in missing properties on the window object that exist in newer browsers. 
However, some browsers like IE8 don't let you set those properties and this assignment causes an exception.