### PR TITLE
Added Ember Handlebars plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Additional Plugins:
 * [JSX](https://github.com/floatdrop/plugin-jsx) `System.import('template.jsx!')`
 * [Markdown](https://github.com/guybedford/plugin-md) `System.import('app/some/project/README.md!').then(function(html) {})`
 * [WebFont](https://github.com/guybedford/plugin-font) `System.import('google Port Lligat Slab, Droid Sans !font')`
+* [Ember Handlebars](https://github.com/n-fuse/plugin-ember-hbs) `System.import('template.hbs!')`
 
 [Read the guide here on creating plugins](https://github.com/systemjs/systemjs/wiki/Creating-a-Plugin).
 


### PR DESCRIPTION
Added the plugin which we use to compile Ember Handlebars templates. It works with Ember 1.10+ and uses ember-template-compiler to actually compile templates.