### PR TITLE
Removed deprecated webkitIndexedDB from ignoredGlobalProps

### DIFF
--- a/lib/extension-global.js
+++ b/lib/extension-global.js
@@ -45,7 +45,7 @@ function global(loader) {
         curGlobalObj = {};
         ignoredGlobalProps = ['indexedDB', 'sessionStorage', 'localStorage',
           'clipboardData', 'frames', 'webkitStorageInfo', 'toolbar', 'statusbar',
-          'scrollbars', 'personalbar', 'menubar', 'locationbar', 'webkitIndexedDB',
+          'scrollbars', 'personalbar', 'menubar', 'locationbar',
           'screenTop', 'screenLeft'
         ];
         for (var g in loader.global) {


### PR DESCRIPTION
Chrome now shows:

![screen shot 2015-04-09 at 10 52 52 am](https://cloud.githubusercontent.com/assets/844249/7069408/9903db58-dea6-11e4-80b8-4445daad22ae.png)

This PR removed `webkitIndexedDB` from `ignoredGlobalProps`.

*Note: I haven't committed any dist/ assets as I presume you take care of that when you cut a release.*

Thanks for all your hard work!