### PR TITLE
Add TypeScript support to SystemJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SystemJS
 
 _For upgrading to SystemJS 0.16, see the [ES6 Module Loader 0.16 release upgrade notes for more information](https://github.com/ModuleLoader/es6-module-loader/releases/tag/v0.16.0), or read the updated [Getting Started](#getting-started) guide below._
 
-Universal dynamic module loader - loads ES6 modules, AMD, CommonJS and global scripts in the browser and NodeJS. Works with both Traceur and Babel.
+Universal dynamic module loader - loads ES6 modules, AMD, CommonJS and global scripts in the browser and NodeJS. Works with Traceur, Babel and TypeScript.
 
 * [Loads any module format](https://github.com/systemjs/systemjs/wiki/Module-Format-Support) with [exact circular reference and binding support](https://github.com/ModuleLoader/es6-module-loader/wiki/Circular-References-&-Bindings).
 * Loads [ES6 modules compiled into the `System.register` bundle format for production](https://github.com/systemjs/systemjs/wiki/Production-Workflows), maintaining circular references support.
@@ -60,7 +60,16 @@ For use with Babel, locate the `browser.js` file at `babel.js` in the baseURL an
 </script>
 ```
 
-Alternatively a custom path to Babel or Traceur can also be set through paths:
+For use with TypeScript, locate `typescript.js` in the baseURL path and set:
+
+```html
+<script>
+  System.transpiler = 'typescript';
+  System.meta['typescript'] = { format: 'global', exports: 'ts' };
+</script>
+```
+
+Alternatively a custom path to Babel, Traceur or TypeScript can also be set through paths:
 
 ```javascript
 System.config({
@@ -78,7 +87,7 @@ To load modules in NodeJS, install SystemJS with:
   npm install systemjs traceur
 ```
 
-(making sure to also install Traceur or Babel as needed, as they are not included as dependencies as of SystemJS 0.16)
+(making sure to also install Traceur, Babel or TypeScript as needed, as they are not included as dependencies as of SystemJS 0.16)
 
 We can then load modules equivalently to in the browser:
 
@@ -88,7 +97,9 @@ var System = require('systemjs');
 /* 
  * Include
  *   System.transpiler = 'babel';
- * to use Babel instead of Traceur
+ * to use Babel or 
+ *   System.transpiler = 'typescript'
+ * to use TypeScript instead of Traceur
  */
 
 // loads './app.js' from the current directory
@@ -149,4 +160,3 @@ License
 ---
 
 MIT
-

--- a/lib/extension-es6.js
+++ b/lib/extension-es6.js
@@ -53,6 +53,9 @@ function es6(loader) {
         configNodeGlobal(self, 'babel/external-helpers', 'babel-core/external-helpers.js');
         configNodeGlobal(self, 'babel-runtime/*', 'babel-runtime', true);
       }
+      else if (self.transpiler == 'typescript') {
+        configNodeGlobal(self, 'typescript', 'typescript/bin/typescript.js');
+      }
       firstLoad = false;
     }
     return loaderLocate.call(self, load);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "babel-core": "^5.0.10",
     "qunit": "^0.6.2",
     "uglify-js": "~2.4.13",
-    "traceur": "0.0.88"
+    "traceur": "0.0.88",
+    "typescript": "mhegazy/typescript#v1.5-beta2"
   },
   "scripts": {
     "test": "npm run test:babel && npm run test:traceur",

--- a/test/test-typescript.html
+++ b/test/test-typescript.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+	<head>
+		<link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+	</head>
+	<body>
+
+		<h1 id="qunit-header">SystemJS Test Suite</h1>
+
+		<h2 id="qunit-banner"></h2>
+		<div id="qunit-testrunner-toolbar"></div>
+		<h2 id="qunit-userAgent"></h2>
+		<ol id="qunit-tests"></ol>
+		<div id="qunit-test-area"></div>
+
+		<!-- <script src="../bower_components/traceur/traceur.js"></script> -->
+		<script src="../node_modules/es6-module-loader/dist/es6-module-loader.src.js"></script>
+		<script src="../dist/system.src.js" type="text/javascript"></script>
+		<script>
+			System.paths['typescript'] = '../node_modules/typescript/bin/typescript.js';
+			System.meta['typescript'] = { format: 'global', exports: 'ts' };
+			System.transpiler = 'typescript';
+			System['import']('test')['catch'](function(e) {
+				setTimeout(function() {
+					throw e;
+				})
+			});
+		</script>
+
+		<script src="../bower_components/qunit/qunit/qunit.js"></script>
+	</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -531,6 +531,8 @@ asyncTest('Loading dynamic modules with __esModule flag set', function() {
 if (ie8)
   return;
 
+// TypeScript does not support async functions yet
+if (System.transpiler !== 'typescript')
 asyncTest('Async functions', function() {
   System.babelOptions = { stage: 0 };
   System.traceurOptions = { asyncFunctions: true };
@@ -540,6 +542,7 @@ asyncTest('Async functions', function() {
   });
 });
 
+if (System.transpiler !== 'typescript')
 asyncTest('Wrapper module support', function() {
   System['import']('tests/wrapper').then(function(m) {
     ok(m['default'] == 'default1', 'Wrapper module not defined.');
@@ -718,10 +721,10 @@ asyncTest('Loading an AMD module that requires another works', function() {
 });
 
 asyncTest('Loading a connected tree that connects ES and CJS modules', function(){
-	System['import']('tests/connected-tree/a').then(function(a){
-		ok(a.name === "a");
-		start();
-	});
+    System['import']('tests/connected-tree/a').then(function(a){
+        ok(a.name === "a");
+        start();
+    });
 });
 
 asyncTest('Loading two bundles that have a shared dependency', function() {

--- a/test/tests/worker-typescript.js
+++ b/test/tests/worker-typescript.js
@@ -1,0 +1,16 @@
+importScripts('../../node_modules/es6-module-loader/dist/es6-module-loader.js',
+              '../../dist/system.js');
+
+System.baseURL = '../';
+System.paths['typescript'] = '../../node_modules/typescript/bin/typescript.js';
+System.meta['typescript'] = { format: 'global', exports: 'ts' };
+System.transpiler = 'typescript';
+
+System.import('tests/es6-and-amd').then(function(m) {
+  postMessage({
+    amd: m.amd_module,
+    es6: m.es6_module
+  });
+}, function(err) {
+  console.error(err);
+});


### PR DESCRIPTION
1. This PR uses  version of TypeScript that was not yet released (because of that dependency uses GitHub link), I'll update this PR to update dependency after TypeScript is released.
2. This PR requires changes to es6-module-loader that are still in flight (PR: https://github.com/ModuleLoader/es6-module-loader/pull/366) - I'll update this PR with a proper version of ES6 module loader once required changes are approved.
3. There is one test 'Wrapper module support' that is currently failing and thus excluded. From what I see this test assumes that `export *` can provide a default export and from my reading of the spec this is not correct:

**[15.2.1.16.2 GetExportedNames( exportStarSet ) Concrete Method](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-getexportednames)**

>For each ExportEntry Record e in module.[[StarExportEntries]], do
Let requestedModule be HostResolveImportedModule(module, e.[[ModuleRequest]]).
ReturnIfAbrupt(requestedModule).
Let starNames be requestedModule.GetExportedNames(exportStarSet).
For each element n of starNames, do
If SameValue(n, "default") is false, then
If n is not an element of exportedNames, then
Append n to exportedNames.


**[15.2.1.16.3 ResolveExport( exportName, resolveSet, exportStarSet ) Concrete Method](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-resolveexport)**

>If SameValue(exportName, "default") is true, then
Assert: A default export was not explicitly defined by this module.
Throw a SyntaxError exception.
NOTE A default export cannot be provided by an export *.

Behavior asserted by this test does not seem to be correct and looks more like bugs in Traceur and Babel