### PR TITLE
Ensure System refers to the current loader

### DIFF
--- a/lib/amd.js
+++ b/lib/amd.js
@@ -49,7 +49,7 @@
         if (loader.execute !== false) {
           var removeDefine = this.get('@@amd-helpers').createDefine(loader);
 
-          __exec(load);
+          __exec.call(loader, load);
 
           removeDefine(loader);
 

--- a/lib/cjs.js
+++ b/lib/cjs.js
@@ -89,7 +89,7 @@
           var define = __global.define;
           __global.define = undefined;
 
-          __exec(load, globals, exports);
+          __exec.call(loader, load, globals, exports);
 
           __global.define = define;
 

--- a/lib/global-eval.js
+++ b/lib/global-eval.js
@@ -6,8 +6,9 @@ var __exec;
 
   // System clobbering protection (mostly for Traceur)
   var curSystem;
-  function preExec() {
+  function preExec(loader) {
     curSystem = __global.System;
+    __global.System = loader;
   }
   function postExec() {
     __global.System = curSystem;
@@ -70,7 +71,7 @@ var __exec;
       window.onerror = function(_e) {
         e = addToError(_e, 'Evaluating ' + load.address);
       }
-      preExec();
+      preExec(this);
       head.appendChild(script);
       head.removeChild(script);
       postExec();
@@ -85,7 +86,7 @@ var __exec;
   else if (isWorker) {
     __exec = function(load, globals, thisValue) {
       try {
-        preExec();
+        preExec(this);
         new Function(getSource(load, globals, thisValue)).call(__global);
         postExec();
         __global._g = undefined;
@@ -101,7 +102,7 @@ var __exec;
     var vm = require(vmModule);
     __exec = function(load, globals, thisValue) {
       try {
-        preExec();
+        preExec(this);
         vm.runInThisContext(getSource(load, globals, thisValue));
         postExec();
         __global._g = undefined;

--- a/lib/global.js
+++ b/lib/global.js
@@ -83,7 +83,7 @@
               globals[g] = require(load.metadata.globals[g]);
           }
 
-          __exec(load, globals);
+          __exec.call(loader, load, globals);
 
           __global.require = cRequire;
           __global.define = define;

--- a/lib/register.js
+++ b/lib/register.js
@@ -486,7 +486,7 @@
 
         __global.System = loader;
 
-        __exec(load);
+        __exec.call(loader, load);
 
         __global.System = curSystem;
 

--- a/lib/scriptLoader.js
+++ b/lib/scriptLoader.js
@@ -79,6 +79,7 @@
         }
 
         curSystem = __global.System;
+        __global.System = loader;
         s.src = load.address;
         head.appendChild(s);
 


### PR DESCRIPTION
This allows bundles of `System.register` and dynamic `System.import` to always refer to the current loader regardless of the `window.System` value.

Not sure how much sense this makes at a spec level though.