### PR TITLE
config-api.md GFM internal links are lower-case

### DIFF
--- a/docs/config-api.md
+++ b/docs/config-api.md
@@ -20,17 +20,17 @@ For this reason it is usually advisable to use `System.config` instead of settin
 
 ### Configuration Options
 
-* [babelOptions](#babelOptions)
+* [babelOptions](#babeloptions)
 * [bundle](#bundle)
-* [defaultJSExtensions](#defaultJSExtensions)
-* [depCache](#depCache)
+* [defaultJSExtensions](#defaultjsextensions)
+* [depCache](#depcache)
 * [map](#map)
 * [meta](#meta)
 * [packages](#packages)
 * [paths](#paths)
-* [traceurOptions](#traceurOptions)
+* [traceurOptions](#traceuroptions)
 * [transpiler](#transpiler)
-* [typescriptOptions](#typescriptOptions)
+* [typescriptOptions](#typescriptoptions)
 
 #### babelOptions
 Type: `Object`


### PR DESCRIPTION
a curious feature (or maybe bug) of GFM I never noticed before - it auto-creates links, but converts camel-case to lower-case. With this change all the links in this file should now work :-)

If I spot any others that don't work, I'll change them too.