### PR TITLE
Pathing adjustments - possible 0.18

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -137,7 +137,7 @@ SystemJSLoader.prototype.config = function(cfg) {
           var normalized = this.normalizeSync(p);
 
           // if doing default js extensions, undo to get package name
-          if (this.defaultJSExtensions)
+          if (this.defaultJSExtensions && p.substr(p.length - 3, 3) != '.js')
             normalized = normalized.substr(0, normalized.length - 3);
 
           // if a package main, revert it
@@ -150,7 +150,6 @@ SystemJSLoader.prototype.config = function(cfg) {
           }
           if (pkgMatch && this.packages[pkgMatch].main)
             normalized = normalized.substr(0, normalized.length - this.packages[pkgMatch].main.length - 1);
-
 
           var pkg = this.packages[normalized] = this.packages[normalized] || {};
           pkg.map = v[p];

--- a/lib/package.js
+++ b/lib/package.js
@@ -19,9 +19,10 @@
  *     map: {
  *        // map internal require('sizzle') to local require('./vendor/sizzle')
  *        sizzle: './vendor/sizzle.js',
- *
+ *     },
+ *     paths: {
  *        // map any internal or external require of 'jquery/vendor/another' to 'another/index.js'
- *        './vendor/another': 'another/index.js'
+ *        'vendor/anotherd': 'another/index.js'
  *      }
  *    }
  *  }
@@ -35,11 +36,11 @@
  *
  * Detailed Behaviours
  * - main is the only property where a leading "./" can be added optionally
- * - map and defaultExtension are applied to the main
+ * - paths and defaultExtension are applied to the main
  * - defaultExtension adds the extension only if no other extension is present
- * - if a map or meta value is available for a module without defaultExtension, defaultExtension is skipped
+ * - defaultExtensions applies after paths
+ * - if a meta value is available for a module, paths and defaultExtension are skipped
  * - like global map, package map also applies to subpaths (sizzle/x, ./vendor/another/sub)
- * - map targets do not pass through any further map or defaultExtension
  *
  * In addition, the following meta properties will be allowed to be package
  * -relative as well in the package meta config:
@@ -108,7 +109,6 @@
 
         // main
         if (pkgName === normalized) {
-
           // no package main -> just use package itself
           if (!pkg.main)
             return normalized;
@@ -120,11 +120,13 @@
         if (pkg.defaultExtension && normalized.split('/').pop().indexOf('.') == -1)
           defaultExtension = '.' + pkg.defaultExtension;
 
-        // apply map checking without then with defaultExtension
-        var subPath = '.' + normalized.substr(pkgName.length);
-        var mapped = applyMap(pkg.map, subPath) || defaultExtension && applyMap(pkg.map, subPath + defaultExtension);
-        if (mapped)
-          normalized = mapped.substr(0, 2) == './' ? pkgName + mapped.substr(1) : mapped;
+        // apply paths checking without then with defaultExtension
+        if (pkg.paths) {
+          var subPath = normalized.substr(pkgName.length + 1);
+          var mapped = applyPaths(pkg.paths, subPath) || defaultExtension && applyPaths(pkg.paths, subPath + defaultExtension);
+          if (mapped)
+            normalized = pkgName + '/' + mapped;
+        }
 
         // apply default extension if not in meta and not the package itself
         else if (defaultExtension && (!pkg.meta || !pkg.meta[subPath.substr(2)]))

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -4,6 +4,13 @@
  * Applies paths and normalizes to a full URL
  */
 hook('normalize', function(normalize) {
+
+  function getExt(name) {
+    var extParts = name.split('/').pop().split('.');
+    if (extParts.length > 1)
+      return extParts.pop();
+  }
+
   return function(name, parentName) {
     var normalized = normalize.call(this, name, parentName);
 
@@ -11,15 +18,22 @@ hook('normalize', function(normalize) {
     if (this.has(normalized))
       return normalized;
 
-    // automatic js extension adding for backwards compatibility
-    if (this.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js')
-      normalized += '.js';
+    var ext = getExt(normalized);
 
-    if (normalized.match(absURLRegEx))
+    if (normalized.match(absURLRegEx)) {
+      // defaultJSExtensions backwards compatibility
+      if (this.defaultJSExtensions && ext !== 'js')
+        normalized += '.js';
       return normalized;
+    }
 
     // applyPaths implementation provided from ModuleLoader system.js source
-    normalized = applyPaths(this, normalized) || normalized;
+    normalized = applyPaths(this.paths, normalized) || normalized;
+
+    // defaultJSExtensions backwards compatibility
+    // if the extension hasn't changed, and the extension is not js, add js
+    if (ext == getExt(normalized) && ext != 'js')
+      normalized += '.js';
 
     // ./x, /x -> page-relative
     if (normalized[0] == '.' || normalized[0] == '/')

--- a/test/test-jsextensions.html
+++ b/test/test-jsextensions.html
@@ -36,6 +36,30 @@
 			    start();
 			  });
 			});
+
+			asyncTest('Pathing extension handling', function() {
+			  System.config({
+			  	paths: {
+			  		'*': '*',
+			  		'another': 'tests/main.js',
+			  		'test/*': 'tests/*.ts'
+			  	}
+			  });
+
+			  Promise.all([
+			  	System['import']('test/typescript'),
+			  	System['import']('another'),
+			  	System['import']('tests/main-dep'),
+			  	System['import']('tests/main-dep.js')
+			  ])
+			  .then(function(mods) {
+			  	ok(mods[0] == 'typescript');
+			  	ok(mods[1].dep == 'value');
+			  	ok(mods[2].dep == 'value');
+			  	ok(mods[2] == mods[3]);
+			  	start();
+			  })
+			});
 		</script>
 	</body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -840,10 +840,11 @@ asyncTest('Package configuration CommonJS config example', function() {
           '*.json': { loader: './json.js' },
           'noext': { alias: './json.json' },
         },
-        map: {
-          './json': './json.json',
-          './dir/': './dir/index.js',
-          './dir2': './dir2/index.json'
+        paths: {
+          'json': 'json.json',
+          'dir/': 'dir/index.js',
+          'dir2': 'dir2/index.json',
+          'dir/*': '*.ts'
         }
       }
     }
@@ -853,12 +854,14 @@ asyncTest('Package configuration CommonJS config example', function() {
     System['import']('tests/testpkg'),
     System['import']('tests/testpkg/json'),
     System['import']('tests/testpkg/dir/'),
-    System['import']('tests/testpkg/dir2')
+    System['import']('tests/testpkg/dir2'),
+    System['import']('tests/testpkg/dir/test')
   ]).then(function(m) {
     ok(m[0].prop == 'value');
     ok(m[1].prop == 'value');
     ok(m[2] == 'dirindex');
     ok(m[3].json == 'index');
+    ok(m[4] == 'ts');
     start();
   }, err);
 });

--- a/test/tests/testpkg/test.ts
+++ b/test/tests/testpkg/test.ts
@@ -1,0 +1,1 @@
+module.exports = 'ts';

--- a/test/tests/typescript.ts
+++ b/test/tests/typescript.ts
@@ -1,0 +1,1 @@
+module.exports = 'typescript';


### PR DESCRIPTION
Two features which are breaking against 0.17, but which may be useful API adjustments at this point:

1. TypeScript users need to use custom extensions with `defaultJSExtensions` compatibility mode. We enable this by making js extensions behave after paths instead of before, and if a path changes the file extension, we don't add the js extension. See https://github.com/systemjs/systemjs/issues/506 for more info.
2. A smaller one, but also breaking - package map config maps two types of requires - paths within the package and also requires within the package. These are really two separate concerns, which is made clearer by calling these paths and map which is more in line with the terminology. This also allows more flexibility against some edge cases that might have caused issues. See https://github.com/systemjs/systemjs/issues/507 for more info.