### PR TITLE
When using `defaultJSExtensions`, prevents `.js` from being appended for module names matching a `meta` config resembling System.meta['*.extension'] = { loader: 'some-loader'}

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -142,6 +142,27 @@ SystemJSLoader.prototype.config = function(cfg) {
       this.paths[p] = cfg.paths[p];
   }
 
+  // use `normalized.match(this.wildcardLoaders)` to prevent `.js` from being 
+  // appended to the normalized name when using `defaultJSExtensions` while 
+  // matching a `meta` key in the form of `*.extension` with a `loader` option
+  //
+  // e.g., System.meta['*.css'] = { loader: 'css' }
+  //       will prevent 'style.css' from becoming 'style.css.js'
+  if (cfg.meta && (cfg.defaultJSExtensions || this.defaultJSExtensions)) {
+    var meta = cfg.meta;
+    var extensions = [];
+
+    for (var module in meta) {
+      if (module.substr(0, 2) == '*.' && meta[module].loader) {
+        extensions.push(module.substr(2));
+      }
+    }
+
+    if (extensions.length) {
+      this.wildcardLoaders = new RegExp('\\.' + extensions.join('|') + '$');
+    }
+  }
+
   if (cfg.map) {
     for (var p in cfg.map) {
       var v = cfg.map[p];
@@ -151,8 +172,9 @@ SystemJSLoader.prototype.config = function(cfg) {
         var normalized = this.normalizeSync(p);
 
         // if doing default js extensions, undo to get package name
-        if (this.defaultJSExtensions && p.substr(p.length - 3, 3) != '.js')
+        if (this.defaultJSExtensions && p.substr(p.length - 3, 3) != '.js' && !normalized.match(this.wildcardLoaders)) {
           normalized = normalized.substr(0, normalized.length - 3);
+        }
 
         // if a package main, revert it
         var pkgMatch = '';
@@ -179,7 +201,7 @@ SystemJSLoader.prototype.config = function(cfg) {
       var prop = this.normalizeSync(p);
 
       // if doing default js extensions, undo to get package name
-      if (this.defaultJSExtensions && p.substr(p.length - 3, 3) != '.js')
+      if (this.defaultJSExtensions && p.substr(p.length - 3, 3) != '.js' && !prop.match(this.wildcardLoaders))
         prop = prop.substr(0, prop.length - 3);
 
       this.packages[prop]= this.packages[prop] || {};

--- a/lib/package.js
+++ b/lib/package.js
@@ -101,7 +101,7 @@
         }
       }
 
-      var defaultJSExtension = this.defaultJSExtensions && name.substr(name.length - 3, 3) != '.js';
+      var defaultJSExtension = this.defaultJSExtensions && name.substr(name.length - 3, 3) != '.js' && !name.match(this.wildcardLoaders);
 
       // apply global map, relative normalization
       var normalized = normalize.call(this, name, parentName);
@@ -109,7 +109,7 @@
       // undo defaultJSExtension
       if (normalized.substr(normalized.length - 3, 3) != '.js')
         defaultJSExtension = false;
-      if (defaultJSExtension)
+      if (defaultJSExtension && !normalized.match(this.wildcardLoaders))
         normalized = normalized.substr(0, normalized.length - 3);
 
       // check if we are inside a package

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -7,6 +7,7 @@ hook('normalize', function(normalize) {
 
   return function(name, parentName) {
     var normalized = normalize.call(this, name, parentName);
+    var wildcardLoader = normalized.match(this.wildcardLoaders);
 
     // if the module is in the registry already, use that
     if (this.has(normalized))
@@ -14,7 +15,7 @@ hook('normalize', function(normalize) {
 
     if (normalized.match(absURLRegEx)) {
       // defaultJSExtensions backwards compatibility
-      if (this.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js')
+      if (!wildcardLoader && this.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js')
         normalized += '.js';
       return normalized;
     }
@@ -23,7 +24,7 @@ hook('normalize', function(normalize) {
     normalized = applyPaths(this.paths, normalized) || normalized;
 
     // defaultJSExtensions backwards compatibility
-    if (this.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js')
+    if (!wildcardLoader && this.defaultJSExtensions && normalized.substr(normalized.length - 3, 3) != '.js')
       normalized += '.js';
 
     // ./x, /x -> page-relative

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -25,7 +25,7 @@
       // note if normalize will add a default js extension
       // if so, remove for backwards compat
       // this is strange and sucks, but will be deprecated
-      var defaultExtension = loader.defaultJSExtensions && argumentName.substr(argumentName.length - 3, 3) != '.js';
+      var defaultExtension = loader.defaultJSExtensions && argumentName.substr(argumentName.length - 3, 3) != '.js' && !argumentName.match(loader.wildcardLoaders);
 
       if (sync) {
         argumentName = loader.normalizeSync(argumentName, parentName);


### PR DESCRIPTION
For example, with this config:
```js
System.config({
  "baseURL": "/",
  "defaultJSExtensions": true,
  "transpiler": "babel",
  "babelOptions": {
    "stage": 0,
    "optional": [
      "runtime"
    ]
  },
  "paths": {
    "github:*": "jspm_packages/github/*",
    "npm:*": "jspm_packages/npm/*"
  }
});

System.config({
  "meta": {
    "*.css": {
      "loader": "css"
    },
    "*.json": {
      "loader": "json"
    },
    "*.jsx": {
      "loader": "jsx"
    }
  }
});
```

The following code will look for `style.css` instead of `style.css.js`, `data.json` instead of `data.json.js`, and `component.jsx` instead of `component.jsx.js`:
```js
var style = require('style.css');
var json = require('data.json');
var Component = require('component.jsx');
```