### PR TITLE
prevented execution of module getters on import

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -366,7 +366,6 @@
       entry.esModule = exports;
     }
     else {
-      var hasOwnProperty = exports && exports.hasOwnProperty;
       entry.esModule = {};
 
       // don't trigger getters/setters in environments that support them

--- a/lib/register.js
+++ b/lib/register.js
@@ -368,9 +368,20 @@
     else {
       var hasOwnProperty = exports && exports.hasOwnProperty;
       entry.esModule = {};
-      for (var p in exports) {
-        if (!hasOwnProperty || exports.hasOwnProperty(p))
-          entry.esModule[p] = exports[p];
+
+      // don't trigger getters/setters in environments that support them
+      if (Object.getOwnPropertyDescriptor) {
+        var d;
+        for (var p in exports)
+          if (d = Object.getOwnPropertyDescriptor(exports, p))
+            Object.defineProperty(entry.esModule, p, d);
+      } else {
+        var hasOwnProperty = exports && exports.hasOwnProperty;
+        entry.esModule = {};
+        for (var p in exports) {
+          if (!hasOwnProperty || exports.hasOwnProperty(p))
+            entry.esModule[p] = exports[p];
+        }
       }
       entry.esModule['default'] = exports;
       defineProperty(entry.esModule, '__useDefault', {

--- a/lib/register.js
+++ b/lib/register.js
@@ -377,7 +377,6 @@
             Object.defineProperty(entry.esModule, p, d);
       } else {
         var hasOwnProperty = exports && exports.hasOwnProperty;
-        entry.esModule = {};
         for (var p in exports) {
           if (!hasOwnProperty || exports.hasOwnProperty(p))
             entry.esModule[p] = exports[p];


### PR DESCRIPTION
I made this change in an effort to get Express working. I also had to change "negotiator" under "npm:accepts@1.1.4" in my config.js. It was at version 0.4.9 and I bumped it up to 0.5.0. That got everything working with jspm run.

edit: sorry for the multiple commits. I had to (improperly) re-make these changes in github's editor.