### PR TITLE
Fix for when condtional module has __useDefault

### DIFF
--- a/lib/conditionals.js
+++ b/lib/conditionals.js
@@ -77,10 +77,14 @@
         return loader['import'](conditionModule, parentName, parentAddress)
         .then(function(m) {
           var conditionValue = readMemberExpression(conditionExport, m);
+          
+          if (typeof conditionValue === 'undefined') {
+            conditionValue = m;
+          }
 
           if (substitution) {
             if (typeof conditionValue !== 'string')
-              throw new TypeError('The condition value for ' + conditionalMatch[0] + ' doesn\'t resolving to a string.');
+              throw new TypeError('The condition value for ' + conditionalMatch[0] + ' doesn\'t resolve to a string.');
             name = name.replace(conditionalRegEx, conditionValue);
           }
           else {


### PR DESCRIPTION
If a module has __useDefault set to true, and exports anything which doesn't have conditionExport's value as a prop, the readMemberExpression function will return undefined. 
For example, I have a module that exports "browser", and has __useDefault set to true. The import promise will return just a string "browser". Than, readMemberExpression, looks for a prop call "default" on the "browser" string, once it is not found, it returns undefined. Later, causing a red herring error, as if the export is not resolving to a string. 
(On the way fixed the error message too).