### PR TITLE
Add main property in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "systemjs",
+  "main": "./dist/system.js",
   "devDependencies": {
     "qunit": "~1.12.0"
   }


### PR DESCRIPTION
Add missing main property, it allows automation using main-bower-files tool.

```json
{
  "name": "systemjs",
  "main": "./dist/system.js",
  "devDependencies": {
    "qunit": "~1.12.0"
  }
}
```