### PR TITLE
Fix load order for dependencies of aliased entries

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -11,11 +11,12 @@
   hook('fetch', function(fetch) {
     return function(load) {
       var alias = load.metadata.alias;
+      var aliasDeps = load.metadata.deps || [];
       if (alias) {
         load.metadata.format = 'defined';
         this.defined[load.name] = {
           declarative: true,
-          deps: [alias],
+          deps: aliasDeps.concat([alias]),
           declare: function(_export) {
             return {
               setters: [function(module) {


### PR DESCRIPTION
Currently, if you define an alias to on an entry and add dependencies for the alias the aliased entry gets loaded before its dependencies.

```javascript
System.config({
  "meta": {
    "a": {
      "alias": "b/submodule",
      "format": "global",
      "exports": "b",
      "deps": [
        "b/submodule-dependency"
      ]
    }
}
```

In the above case `b/submodule` would be loaded before `b/submodule-dependency`.