### PR TITLE
correctly handle duplicate entries in dependency list

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -28,6 +28,22 @@ function dedupe(deps) {
   return newDeps;
 }
 
+function group(deps) {
+  var names = [];
+  var indices = [];
+  for (var i = 0, l = deps.length; i < l; i++) {
+    var index = indexOf.call(names, deps[i]);
+    if (index === -1) {
+      names.push(deps[i]);
+      indices.push([i]);
+    }
+    else {
+      indices[index].push(i);
+    }
+  }
+  return { names: names, indices: indices };
+}
+
 function extend(a, b, underwrite) {
   for (var p in b) {
     if (!underwrite || !(p in a))

--- a/lib/register.js
+++ b/lib/register.js
@@ -292,10 +292,15 @@
       else {
         module.dependencies.push(null);
       }
-
-      // run the setter for this dependency
-      if (module.setters[i])
-        module.setters[i](depExports);
+      
+      // run setters for all entries with the matching dependency name
+      var originalIndices = entry.originalIndices[i];
+      for (var j = 0, len = originalIndices.length; j < len; ++j) {
+        var index = originalIndices[j];
+        if (module.setters[index]) {
+          module.setters[index](depExports);
+        }
+      }
     }
   }
 
@@ -534,8 +539,10 @@
 
       // place this module onto defined for circular references
       loader.defined[load.name] = entry;
-
-      entry.deps = dedupe(entry.deps);
+      
+      var grouped = group(entry.deps);
+      
+      entry.deps = grouped.names;
       entry.name = load.name;
 
       // first, normalize all dependencies
@@ -546,7 +553,8 @@
       return Promise.all(normalizePromises).then(function(normalizedDeps) {
 
         entry.normalizedDeps = normalizedDeps;
-
+        entry.originalIndices = grouped.indices;
+        
         return {
           deps: entry.deps,
           execute: function() {

--- a/lib/register.js
+++ b/lib/register.js
@@ -554,7 +554,7 @@
       return Promise.all(normalizePromises).then(function(normalizedDeps) {
 
         entry.normalizedDeps = normalizedDeps;
-        
+
         return {
           deps: entry.deps,
           execute: function() {

--- a/lib/register.js
+++ b/lib/register.js
@@ -543,6 +543,7 @@
       var grouped = group(entry.deps);
       
       entry.deps = grouped.names;
+      entry.originalIndices = grouped.indices;
       entry.name = load.name;
 
       // first, normalize all dependencies
@@ -553,7 +554,6 @@
       return Promise.all(normalizePromises).then(function(normalizedDeps) {
 
         entry.normalizedDeps = normalizedDeps;
-        entry.originalIndices = grouped.indices;
         
         return {
           deps: entry.deps,

--- a/test/test.js
+++ b/test/test.js
@@ -803,6 +803,14 @@ if(typeof window !== 'undefined' && window.Worker) {
   });
 }
 
+asyncTest("Duplicate entries", function() {
+  System["import"]('tests/duplicateDeps/m1.js').then(function(m) {
+    var r = m.foo() + ":" + m.f3();
+    ok(r === "3:3", "duplicate entries in dependency list not handled correctly");
+    start();
+  })
+});
+
 // new features!!
 
 asyncTest('Named imports for non-es6', function() {

--- a/test/tests/duplicateDeps/m1.js
+++ b/test/tests/duplicateDeps/m1.js
@@ -1,0 +1,23 @@
+System.register(["tests/duplicateDeps/m2.js", "tests/duplicateDeps/m2.js", "tests/duplicateDeps/m2.js"], function(exports_1) {
+    var m2_1, m2_2;
+    function foo() {
+        return m2_1.f1() + m2_2.f2();
+    }
+    exports_1("foo", foo);
+    return {
+        setters:[
+            function (_m2_1) {
+                m2_1 = _m2_1;
+            },
+            function (_m2_2) {
+                m2_2 = _m2_2;
+            },
+            function (_m2_3) {
+                var reexports_1 = {};
+                reexports_1["f3"] = _m2_3["f3"];
+                exports_1(reexports_1);
+            }],
+        execute: function() {
+        }
+    }
+});

--- a/test/tests/duplicateDeps/m2.js
+++ b/test/tests/duplicateDeps/m2.js
@@ -1,0 +1,13 @@
+System.register([], function(exports_1) {
+    function f1() { return 1; }
+    exports_1("f1", f1);
+    function f2() { return 2; }
+    exports_1("f2", f2);
+    function f3() { return 3; }
+    exports_1("f3", f3);
+    return {
+        setters:[],
+        execute: function() {
+        }
+    }
+});


### PR DESCRIPTION
currently if dependency list contains multiple duplicate entries - setter is called only for the first one. This PR fixed this by capturing indices of duplicated from the original dependency list and using them to invoke setters