### PR TITLE
Fixed non-working compilation of dist/system-register-only.src.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ dist/system-register-only.src.js: lib/*.js $(ESML)/*.js
 				lib/proto.js \
 				lib/scriptLoader.js \
 				lib/scriptOnly.js \
+				lib/amd-helpers.js \
 				lib/register.js \
 				lib/createSystem.js \
 		$(ESML)/wrapper-end.js \


### PR DESCRIPTION
In using `system-register-only.js` with `traceur-runtime.js`, the following error is produced when calling System.import() to dynamically load modules:

```
Uncaught (in promise) Error: Cannot read property 'createDefine' of undefined
	Error loading http://localhost:3000/javascripts/main.js
    at SystemJSLoader.<anonymous> (http://localhost:3000/javascripts/system-register-only.js:1218:30)
    at SystemJSLoader.fetch (http://localhost:3000/javascripts/system-register-only.js:1723:20)
    at http://localhost:3000/javascripts/system-register-only.js:325:33
```
This is due to the fact that `lib/scriptOnly.js` calls `this.get('@@amd-helpers')` twice (on line 10 and 21) without the Makefile including `lib/amd-helpers.js` in `dist/system-register-only.js`.

While rewriting `lib/scriptOnly.js` to not rely on the amd-helpers may be preferable, merely including `lib/amd-helpers.js` in the Makefile target for `dist/system-register-only.js` fixes this error.