### PR TITLE
Fix #667

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -398,6 +398,9 @@
           for (var p in exports)
             if (d = Object.getOwnPropertyDescriptor(exports, p))
               defineProperty(entry.esModule, p, d);
+
+          if (!Object.getOwnPropertyDescriptor(exports, 'default'))
+            entry.esModule['default'] = exports;
         }
         else {
           var hasOwnProperty = exports && exports.hasOwnProperty;
@@ -405,9 +408,11 @@
             if (!hasOwnProperty || exports.hasOwnProperty(p))
               entry.esModule[p] = exports[p];
           }
+
+          if (!hasOwnProperty || !exports.hasOwnProperty('default'))
+            entry.esModule['default'] = exports;
         }
-      }
-      entry.esModule['default'] = exports;
+      } else entry.esModule['default'] = exports;
       defineProperty(entry.esModule, '__useDefault', {
         value: true
       });


### PR DESCRIPTION
If module passed to System.register defines exports.default, use it directly.