### PR TITLE
Added AMD-style loader first syntax.

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -76,8 +76,13 @@
       // plugin syntax
       var pluginSyntaxIndex = name.lastIndexOf('!');
       if (pluginSyntaxIndex != -1) {
-        load.metadata.loader = name.substr(pluginSyntaxIndex + 1);
-        load.name = name.substr(0, pluginSyntaxIndex);
+        if (load.metadata.loaderFirst) {
+          load.metadata.loader = name.substr(0, pluginSyntaxIndex);
+          load.name = name.substr(pluginSyntaxIndex + 1);
+        } else {
+          load.metadata.loader = name.substr(pluginSyntaxIndex + 1);
+          load.name = name.substr(0, pluginSyntaxIndex);
+        }
       }
 
       return locate.call(loader, load)

--- a/test/test.js
+++ b/test/test.js
@@ -871,6 +871,22 @@ asyncTest('Wildcard meta', function() {
   });
 });
 
+asyncTest('AMD-style loader first syntax', function() {
+  System.map['bootstrap'] = 'tests/bootstrap@3.1.1';
+  System.map['coffee'] = 'tests/compiler-plugin.js';
+  System.config({
+    meta: {
+      '*': {
+        loaderFirst: true
+      }
+    }
+  })
+  System['import']('coffee!bootstrap/test.coffee').then(function(m) {
+    ok(m.extra == 'yay!', 'not working');
+    start();
+  }, err);
+});
+
 asyncTest('Package configuration CommonJS config example', function() {
   System.config({
     packages: {


### PR DESCRIPTION
This is in response to issue #549.

This is based on how AMD deals with loaders: https://github.com/amdjs/amdjs-api/blob/master/LoaderPlugins.md

Introduces the meta configuration option 'loaderFirst' which can be used to specify this style of loading. Useful for porting existing require.js code bases to System.js. This option tells System.js how to load files *within* a file specified in the meta config. This means it is most useful within the context of a package config which applies to an entire package.

Documentation will need to be updated. One test has been added but more extensive tests are probably needed for this to be a supported feature. Note that while the require.js version supports multiple loaders this has not been tested for the loaderFirst implementation in System.js.