### PR TITLE
Allow for custom error handling.

### DIFF
--- a/lib/global-eval.js
+++ b/lib/global-eval.js
@@ -60,6 +60,8 @@ var __exec;
       var e;
       window.onerror = function(_e) {
         e = addToError(_e, 'Evaluating ' + load.address);
+        if (onerror)
+          onerror.apply(this, arguments);
       }
       preExec(this);
       head.appendChild(script);


### PR DESCRIPTION
I have an application with a `window.onerror` defined, and it seems that SystemJS is overriding it so that the custom function is not called. This updates SystemJS so that it invokes the existing `window.onerror`