### PR TITLE
Loader first global

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -141,6 +141,9 @@ SystemJSLoader.prototype.config = function(cfg) {
   if (cfg.defaultJSExtensions)
     this.defaultJSExtensions = cfg.defaultJSExtensions;
 
+  if (cfg.pluginFirst)
+    this.pluginFirst = cfg.pluginFirst;
+
   if (cfg.paths) {
     for (var p in cfg.paths)
       this.paths[p] = cfg.paths[p];

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -12,29 +12,56 @@
   function normalizePlugin(normalize, name, parentName, sync) {
     var loader = this;
     // if parent is a plugin, normalize against the parent plugin argument only
-    var parentPluginIndex;
-    if (parentName && (parentPluginIndex = parentName.indexOf('!')) != -1)
-      parentName = parentName.substr(0, parentPluginIndex);
+    if (parentName) {
+      var parentPluginIndex;
+      if (loader.pluginFirst) {
+        if ((parentPluginIndex = parentName.lastIndexOf('!')) != -1)
+          parentName = parentName.substr(parentPluginIndex + 1);
+      }
+      else {
+        if ((parentPluginIndex = parentName.indexOf('!')) != -1)
+          parentName = parentName.substr(0, parentPluginIndex);
+      }
+    }
 
     // if this is a plugin, normalize the plugin name and the argument
     var pluginIndex = name.lastIndexOf('!');
     if (pluginIndex != -1) {
-      var argumentName = name.substr(0, pluginIndex);
-      var pluginName = name.substr(pluginIndex + 1) || argumentName.substr(argumentName.lastIndexOf('.') + 1);
+      var argumentName;
+      var pluginName;
+
+      if (loader.pluginFirst) {
+        argumentName = name.substr(pluginIndex + 1);
+        pluginName = name.substr(0, pluginIndex);
+      }
+      else {
+        argumentName = name.substr(0, pluginIndex);
+        pluginName = name.substr(pluginIndex + 1) || argumentName.substr(argumentName.lastIndexOf('.') + 1);
+      }
 
       // note if normalize will add a default js extension
       // if so, remove for backwards compat
       // this is strange and sucks, but will be deprecated
       var defaultExtension = loader.defaultJSExtensions && argumentName.substr(argumentName.length - 3, 3) != '.js';
 
+      // put name back together after parts have been normalized
+      function normalizePluginParts(argumentName, pluginName) {
+        if (defaultExtension && argumentName.substr(argumentName.length - 3, 3) == '.js')
+          argumentName = argumentName.substr(0, argumentName.length - 3);
+
+        if (loader.pluginFirst) {
+          return pluginName + '!' + argumentName;
+        }
+        else {
+          return argumentName + '!' + pluginName;
+        }
+      }
+
       if (sync) {
         argumentName = loader.normalizeSync(argumentName, parentName);
         pluginName = loader.normalizeSync(pluginName, parentName);
 
-        if (defaultExtension && argumentName.substr(argumentName.length - 3, 3) == '.js')
-          argumentName = argumentName.substr(0, argumentName.length - 3);
-
-        return argumentName + '!' + pluginName;
+        return normalizePluginParts(argumentName, pluginName);
       }
       else {
         return Promise.all([
@@ -42,10 +69,7 @@
           loader.normalize(pluginName, parentName)
         ])
         .then(function(normalized) {
-          argumentName = normalized[0];
-          if (defaultExtension && argumentName.substr(argumentName.length - 3, 3) == '.js')
-            argumentName = argumentName.substr(0, argumentName.length - 3);
-          return argumentName + '!' + normalized[1];
+          return normalizePluginParts(normalized[0], normalized[1]);
         });
       }
     }
@@ -74,10 +98,18 @@
       var name = load.name;
 
       // plugin syntax
-      var pluginSyntaxIndex = name.lastIndexOf('!');
-      if (pluginSyntaxIndex != -1) {
-        load.metadata.loader = name.substr(pluginSyntaxIndex + 1);
-        load.name = name.substr(0, pluginSyntaxIndex);
+      var pluginSyntaxIndex;
+      if (loader.pluginFirst) {
+        if ((pluginSyntaxIndex = name.indexOf('!')) != -1) {
+          load.metadata.loader = name.substr(0, pluginSyntaxIndex);
+          load.name = name.substr(pluginSyntaxIndex + 1);
+        }
+      }
+      else {
+        if ((pluginSyntaxIndex = name.lastIndexOf('!')) != -1) {
+          load.metadata.loader = name.substr(pluginSyntaxIndex + 1);
+          load.name = name.substr(0, pluginSyntaxIndex);
+        }
       }
 
       return locate.call(loader, load)

--- a/test/test.js
+++ b/test/test.js
@@ -438,6 +438,17 @@ asyncTest('Mapping a plugin argument', function() {
   }, err);
 });
 
+asyncTest('Using pluginFirst config', function() {
+  System.pluginFirst = true;
+  System.map['bootstrap'] = 'tests/bootstrap@3.1.1';
+  System.map['coffee'] = 'tests/compiler-plugin.js';
+  System['import']('coffee!bootstrap/test.coffee').then(function(m) {
+    ok(m.extra == 'yay!', 'not working');
+    System.pluginFirst = false;
+    start();
+  }, err);
+});
+
 asyncTest('Advanced compiler plugin', function() {
   System['import']('tests/compiler-test.js!tests/advanced-plugin.js').then(function(m) {
     ok(m == 'custom fetch:' + System.baseURL + 'tests/compiler-test.js!' + System.baseURL + 'tests/advanced-plugin.js', m);


### PR DESCRIPTION
The ```pluginFirst``` is a boolean property of loader similar to defaultJSExensions. Setting it to true causes SystemJS to follow the plugin syntax of AMD and webpack, where the plugin name comes before the resource identifier. Old syntax was ```[resource ID]![plugin module ID]```. With pluginFirst turned on, ```[plugin module ID]![resource ID]```. See [https://github.com/amdjs/amdjs-api/blob/master/LoaderPlugins.md](https://github.com/amdjs/amdjs-api/blob/master/LoaderPlugins.md) for exact details. Should resolve issue #549.

so ```System.import('./index.coffee!coffee')```
becomes ```System.import('coffee!./index.coffee")```

Note that the old anonymous plugin support like ```System.import("file.coffee!")``` which is short for ```System.import("file.coffee!coffee")``` is not enabled. ```System.import("!file.coffee")``` doesn't make as much sense but if necessary it can certainly be enabled.

SystemJS builder may also need to be updated for complete support for this option.
