### PR TITLE
Allow multiple simultaneous imports in one call.

### DIFF
--- a/dist/system.src.js
+++ b/dist/system.src.js
@@ -779,6 +779,9 @@ function logloads(loads) {
     },
     // 26.3.3.8
     'import': function(name, parentName, parentAddress) {
+      if (Array.isArray(name){
+        return Promise.all(name.map(this.import.bind(this)));
+      }
       if (typeof parentName == 'object')
         parentName = parentName.name;
 


### PR DESCRIPTION
# Usage
````System.import(['many', 'modules', 'at', 'once']).then(function(modules){ ... }); ````