### PR TITLE
Docs: packages meta path

### DIFF
--- a/docs/config-api.md
+++ b/docs/config-api.md
@@ -217,7 +217,7 @@ System.config({
   Takes preference over defaultJSExtensions. Any filename containing a `.` is considered to have an extension.
   Can be set to `defaultExtension: false` to optionally opt-out of extension-adding when `defaultJSExtensions` is enabled.
 * `map`: Local and relative map configurations scoped to the package. Apply for subpaths as well.
-* `meta`: Package-scoped meta configuration with wildcard support.
+* `meta`: Package-scoped meta configuration with wildcard support. Meta paths are subpaths within the package path.
 
 #### paths
 Type: `Object`


### PR DESCRIPTION
Clarifying that meta paths are subpaths within package paths.
See: https://github.com/systemjs/systemjs/issues/692