### PR TITLE
Enable setting properties on script element.

### DIFF
--- a/docs/config-api.md
+++ b/docs/config-api.md
@@ -181,6 +181,8 @@ System.config({
 * `globals`: A map of global names to modules names that should be defined only for the execution of this module. Enables use of legacy code that expects certain globals to be present. Referenced modules automatically becomes dependencies. Only supported for the `cjs` and `global` formats. More info: [Custom Globals](https://github.com/systemjs/systemjs/blob/master/docs/module-formats.md#custom-globals).
 * `loader`: Set a loader for this meta path. More info: [Plugin loaders](https://github.com/systemjs/systemjs/blob/master/docs/overview.md#plugin-loaders).
 * `sourceMap`: For plugin transpilers to set the source map of their transpilation.
+* `nonce`: The "[nonce](https://www.w3c.org/TR/CSP2/#script-src-the-nonce-attribute)" attribute to use when loading the script. This enables the use of a content security policy when CJS or plugin loaders are used. This should correspond to the "nonce-" attribute set in the Content-Security-Policy header.
+* `integrity`: The "[integrity](http://www.w3.org/TR/SRI/#the-integrity-attribute)" attribute of a resource corresponds to the "script" integrity property describing the expected checksum of a resource. For example, if you know the sha checksum of "src/example.js" to be ```e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855``` then you can set the ```integrity``` of a resource in the System config like ```System.config({meta: {"src/example.js": {integrity: "sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}});```
 
 #### packages
 Type: `Object`
@@ -203,7 +205,7 @@ System.config({
       map: {
         // use local jquery for all jquery requires in this package
         'jquery': './vendor/local-jquery.js'
-        
+
         // import '/local/package/custom-import' should route to '/local/package/local/import/file.js'
         './custom-import': './local/import/file.js'
       }

--- a/lib/global-eval.js
+++ b/lib/global-eval.js
@@ -32,6 +32,8 @@ var __exec;
   // this may lead to some global module execution differences (eg var not defining onto global)
   if (isWorker || isBrowser && window.chrome && window.chrome.extension) {
     __exec = function(load) {
+      if (load.metadata.integrity)
+        throw new Error('Subresource integrity checking is not supported in Web Workers or Chrome Extensions.');
       try {
         preExec(this);
         new Function(getSource(load)).call(__global);
@@ -62,6 +64,12 @@ var __exec;
         e = addToError(_e, 'Evaluating ' + load.address);
       }
       preExec(this);
+
+      if (load.metadata.integrity)
+        script.integrity = load.metadata.integrity;
+      if (load.metadata.nonce)
+        script.nonce = load.metadata.nonce;
+
       head.appendChild(script);
       head.removeChild(script);
       postExec();
@@ -75,6 +83,8 @@ var __exec;
     var vmModule = 'vm';
     var vm = require(vmModule);
     __exec = function(load) {
+      if (load.metadata.integrity)
+        throw new Error('Subresource integrity checking is unavailable in Node.');
       try {
         preExec(this);
         vm.runInThisContext(getSource(load));

--- a/lib/scriptLoader.js
+++ b/lib/scriptLoader.js
@@ -17,6 +17,9 @@
 
   function webWorkerImport(loader, load) {
     return new Promise(function(resolve, reject) {
+      if (load.metadata.integrity)
+        reject(new Error('Subresource integrity checking is not supported in web workers.'));
+
       try {
         importScripts(load.address);
       }
@@ -81,6 +84,12 @@
         curSystem = __global.System;
         __global.System = loader;
         s.src = load.address;
+
+        if (load.metadata.integrity)
+          s.integrity = load.metadata.integrity;
+        if (load.metadata.nonce)
+          s.nonce = load.metadata.nonce;
+
         head.appendChild(s);
 
         function cleanup() {

--- a/test/test-csp-inline.html
+++ b/test/test-csp-inline.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css"/>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-abc';">
+  </head>
+  <body>
+
+    <h1 id="qunit-header">SystemJS Test Suite</h1>
+
+    <h2 id="qunit-banner"></h2>
+    <div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+    <div id="qunit-test-area"></div>
+
+    <script src="../dist/system.src.js" type="text/javascript"></script>
+    <script src="../bower_components/qunit/qunit/qunit.js"></script>
+
+    <script nonce='abc'>
+      QUnit.config.testTimeout = 2000;
+
+      QUnit.module("SystemJS nonce");
+
+      function err(e) {
+        setTimeout(function() {
+          throw e.stack || e;
+          start();
+        });
+      }
+
+      asyncTest('Importing a script with a good nonce', function() {
+        System.config({
+          meta: {
+            'tests/csp/nonce.js': {
+              nonce: 'abc'
+            }
+          }
+        });
+        System['import']('tests/csp/nonce.js').then(function(m) {
+          ok(m.nonce === 'abc');
+          start();
+        });
+      });
+
+      asyncTest('Importing a script without a nonce', function() {
+        System['import']('tests/csp/nonce2.js').then(function(m) {
+          ok(m.nonce !== 'ab');
+          start();
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -179,6 +179,33 @@
         });
       })
       
+      asyncTest('Importing a script with wrong integrity fails', function() {
+        System.config({
+          meta: {
+            'tests/csp/integrity.js': {
+              integrity: 'sha256-abc'
+            }
+          }
+        });
+        System['import']('tests/csp/integrity.js').then(err, function(e) {
+          ok(typeof e !== 'undefined');
+          start();
+        });
+      });
+
+      asyncTest('Importing a script with correct integrity', function() {
+        System.config({
+          meta: {
+            'tests/csp/integrity.js': {
+              integrity: 'sha256-Mqlafeai37CqaOaqrc3_vWRwh7iQLyXxu-UyjtI_BGk='
+            }
+          }
+        });
+        System['import']('tests/csp/integrity.js').then(function(m) {
+          ok(m.integrity === 'integrity');
+          start();
+        });
+      });
     </script>
   </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -962,4 +962,18 @@ asyncTest('Loading a System.registerdynamic module (not bundled)', function() {
   }).then(null, err);
 });
 
+asyncTest('Importing a script with wrong integrity fails', function() {
+  System.config({
+    meta: {
+      'tests/csp/integrity.js': {
+        integrity: 'sha256-abc'
+      }
+    }
+  });
+  System['import']('tests/csp/integrity.js').then(err, function(e) {
+    ok(typeof e !== 'undefined');
+    start();
+  });
+});
+
 })(typeof window == 'undefined' ? global : window);

--- a/test/tests/csp/integrity.js
+++ b/test/tests/csp/integrity.js
@@ -1,0 +1,5 @@
+define(function () {
+  return {
+    integrity: 'integrity'
+  }
+});

--- a/test/tests/csp/nonce.js
+++ b/test/tests/csp/nonce.js
@@ -1,0 +1,3 @@
+module.exports = {
+  nonce: 'abc'
+};

--- a/test/tests/csp/nonce2.js
+++ b/test/tests/csp/nonce2.js
@@ -1,0 +1,3 @@
+module.exports = {
+  nonce: 'ab'
+};


### PR DESCRIPTION
The script loader will use load metadata to set script properties. This allows what is in the script tag to be set in meta.

There are two primary use cases: CSP nonce and subresource integrity.

Users of SystemJS wanting to take advantage of CSP can set a "nonce" value in their CSP config. Setting the meta attribute "nonce" for plugins and formats that cannot use CSP allows safely bypassing CSP. Note that this will only work in places where "document" is available. See the test-csp-inline.html file for a full example.

In addition, subresource checking mentions in #639 is also implemented. In the same way setting "integrity" in the meta should make this possible. See test-csp.html for a full example.