### PR TITLE
Dynamic configuration requests for packages

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -181,6 +181,16 @@ SystemJSLoader.prototype.config = function(cfg) {
     }
   }
 
+  if (cfg.packagePaths) {
+    for (var i = 0; i < cfg.packagePaths.length; i++) {
+      var path = cfg.packagePaths[i];
+      var normalized = this.normalizeSync(path);
+      if (this.defaultJSExtensions && path.substr(path.length - 3, 3) != '.js')
+        normalized = normalized.substr(0, normalized.length - 3);
+      cfg.packagePaths[i] = normalized;
+    }
+  }
+
   if (cfg.packages) {
     for (var p in cfg.packages) {
       var prop = this.normalizeSync(p);

--- a/lib/package.js
+++ b/lib/package.js
@@ -53,6 +53,30 @@
  *   - loader
  *   - alias
  *
+ *
+ * Package Configuration Loading
+ * 
+ * Not all packages may already have their configuration present in the System config
+ * For these cases, a list of packagePaths can be provided, which when matched against
+ * a request, will first request a ".json" file by the package name to derive the package
+ * configuration from. This allows dynamic loading of non-predetermined code, a key use
+ * case in SystemJS.
+ *
+ * Example:
+ * 
+ *   System.packagePaths = ['packages/*'];
+ *
+ *   // will first request 'packages/new-package.json' for the package config
+ *   // before completing the package request to 'packages/new-package/path'
+ *   System.import('packages/new-package/path');
+ *
+ * When a package matches packagePaths, it will always send a config request for
+ * the package configuration.
+ * Any existing package configurations for the package will deeply merge with the 
+ * package config, with the existing package configurations taking preference.
+ * To opt-out of the package configuration request for a package that matches
+ * packagePaths, use the { loadConfig: false } package config option.
+ * 
  */
 (function() {
 
@@ -60,6 +84,7 @@
     return function() {
       constructor.call(this);
       this.packages = {};
+      this.packagePaths = {};
     };
   });
 
@@ -113,6 +138,58 @@
     }
   }
 
+  function applyPackageConfig(normalized, pkgName, sync, defaultJSExtension) {
+    var loader = this;
+    var pkg = loader.packages[pkgName];
+    // main
+    if (pkgName === normalized && pkg.main)
+      normalized += '/' + (pkg.main.substr(0, 2) == './' ? pkg.main.substr(2) : pkg.main);
+
+    if (normalized.substr(pkgName.length) == '/')
+      return normalized;
+
+    // defaultExtension & defaultJSExtension
+    // if we have meta for this package, don't do defaultExtensions
+    var defaultExtension = '';
+    if (!pkg.meta || !(pkg.meta[normalized.substr(pkgName.length + 1)] || pkg.meta['./' + normalized.substr(pkgName.length + 1)])) {
+      // apply defaultExtension
+
+      if ('defaultExtension' in pkg) {
+        if (pkg.defaultExtension !== false && normalized.split('/').pop().lastIndexOf('.') == -1)
+          defaultExtension = '.' + pkg.defaultExtension;
+      }
+      // apply defaultJSExtensions if defaultExtension not set
+      else if (defaultJSExtension) {
+        defaultExtension = '.js';
+      }
+    }
+
+    // sync normalize does not apply package map
+    if (sync || !pkg.map)
+      return normalized + defaultExtension;
+
+    var subPath = '.' + normalized.substr(pkgName.length);
+
+    // apply submap checking without then with defaultExtension
+    return Promise.resolve(envMap(loader, pkgName, pkg.map, subPath))
+    .then(function(mapped) {
+      if (mapped)
+        return mapped;
+
+      if (defaultExtension)
+        return envMap(loader, pkgName, pkg.map, subPath + defaultExtension);
+    })
+    .then(function(mapped) {
+      if (mapped)
+        normalized = mapped.substr(0, 2) == './' ? pkgName + mapped.substr(1) : normalize.call(loader, mapped);
+      else
+        normalized += defaultExtension;
+      return normalized;
+    });
+  }
+
+  var packagePathsRegExps = {};
+  var pkgConfigPromises = {};
   function createPackageNormalize(normalize, sync) {
     return function(name, parentName) {
       // apply contextual package map first
@@ -152,55 +229,49 @@
       var pkgName = getPackage.call(this, normalized);
 
       var loader = this;
-
-      if (pkgName) {
-        var pkg = loader.packages[pkgName];
-        // main
-        if (pkgName === normalized && pkg.main)
-          normalized += '/' + (pkg.main.substr(0, 2) == './' ? pkg.main.substr(2) : pkg.main);
-
-        if (normalized.substr(pkgName.length) == '/')
-          return normalized;
-
-        // defaultExtension & defaultJSExtension
-        // if we have meta for this package, don't do defaultExtensions
-        var defaultExtension = '';
-        if (!pkg.meta || !(pkg.meta[normalized.substr(pkgName.length + 1)] || pkg.meta['./' + normalized.substr(pkgName.length + 1)])) {
-          // apply defaultExtension
-
-          if ('defaultExtension' in pkg) {
-            if (pkg.defaultExtension !== false && normalized.split('/').pop().lastIndexOf('.') == -1)
-              defaultExtension = '.' + pkg.defaultExtension;
-          }
-          // apply defaultJSExtensions if defaultExtension not set
-          else if (defaultJSExtension) {
-            defaultExtension = '.js';
+      
+      // check if we match a packagePaths
+      if (!sync) {
+        var pkgPath;
+        for (var i = 0; i < this.packagePaths.length; i++) {
+          var match = normalized.match(packagePathsRegExps[this.packagePaths[i]] || 
+              (packagePathsRegExps[this.packagePaths[i]] = new RegExp('^' + this.packagePaths[i].replace(/\*/g, '[^\\/]+'))));
+          if (match) {
+            pkgPath = match[0];
+            break;
           }
         }
 
-        // sync normalize does not apply package map
-        if (sync || !pkg.map)
-          return normalized + defaultExtension;
+        if (pkgPath) {
+          return (pkgConfigPromises[pkgPath] || 
+            (pkgConfigPromises[pkgPath] = 
+              loader['fetch']({ name: pkgPath + '.json', address: pkgPath + '.json', metadata: {} })
+              .then(function(source) {
+                try {
+                  return JSON.parse(source);
+                }
+                catch(e) {
+                  throw new Error('Invalid JSON in package configuration file ' + pkgPath);
+                }
+              })
+              .then(function(cfg) {
+                // deeply-merge (to first level) config with any existing package config
+                if (pkgName && pkgName == pkgPath)
+                  extendMeta(cfg, loader.packages[pkgPath]);
 
-        var subPath = '.' + normalized.substr(pkgName.length);
-
-        // apply submap checking without then with defaultExtension
-        return Promise.resolve(envMap(loader, pkgName, pkg.map, subPath))
-        .then(function(mapped) {
-          if (mapped)
-            return mapped;
-
-          if (defaultExtension)
-            return envMap(loader, pkgName, pkg.map, subPath + defaultExtension);
-        })
-        .then(function(mapped) {
-          if (mapped)
-            normalized = mapped.substr(0, 2) == './' ? pkgName + mapped.substr(1) : normalize.call(loader, mapped);
-          else
-            normalized += defaultExtension;
-          return normalized;
-        });
+                loader.packages[pkgPath] = cfg;
+              })
+            )
+          )
+          .then(function() {
+            // finally apply the package config we just created to the current request
+            return applyPackageConfig.call(loader, normalized, pkgPath, sync, defaultJSExtension);
+          });
+        }
       }
+
+      if (pkgName)
+        return applyPackageConfig.call(loader, normalized, pkgName, sync, defaultJSExtension);
       
       // add back defaultJSExtension if not a package
       if (defaultJSExtension)

--- a/lib/package.js
+++ b/lib/package.js
@@ -242,7 +242,7 @@
           }
         }
 
-        if (pkgPath) {
+        if (pkgPath && (!pkgName || pkgName != pkgPath || loader.packages[pkgName].loadConfig !== false)) {
           return (pkgConfigPromises[pkgPath] || 
             (pkgConfigPromises[pkgPath] = 
               loader['fetch']({ name: pkgPath + '.json', address: pkgPath + '.json', metadata: {} })

--- a/test/test.js
+++ b/test/test.js
@@ -884,24 +884,9 @@ asyncTest('Wildcard meta', function() {
 
 asyncTest('Package configuration CommonJS config example', function() {
   System.config({
+    packagePaths: ['tests/testpk*'],
     packages: {
       'tests/testpkg': {
-        main: './noext',
-        format: 'cjs',
-        defaultExtension: 'js',
-        meta: {
-          '*.json': { loader: './json.js' },
-          'noext': { alias: './json.json' },
-        },
-        map: {
-          './json': './json.json',
-          './dir/': './dir/index.js',
-          './dir2': './dir2/index.json',
-          './dir/test': './test.ts',
-          './env-module': {
-            'browser': './env-module-browser.js'
-          }
-        },
         asdf: 'asdf'
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -887,6 +887,7 @@ asyncTest('Package configuration CommonJS config example', function() {
     packagePaths: ['tests/testpk*'],
     packages: {
       'tests/testpkg': {
+        main: './noext',
         asdf: 'asdf'
       }
     }

--- a/test/tests/testpkg.json
+++ b/test/tests/testpkg.json
@@ -1,0 +1,18 @@
+{
+  "main": "./noext",
+  "format": "cjs",
+  "defaultExtension": "js",
+  "meta": {
+    "*.json": { "loader": "./json.js" },
+    "noext": { "alias": "./json.json" }
+  },
+  "map": {
+    "./json": "./json.json",
+    "./dir/": "./dir/index.js",
+    "./dir2": "./dir2/index.json",
+    "./dir/test": "./test.ts",
+    "./env-module": {
+      "browser": "./env-module-browser.js"
+    }
+  }
+}

--- a/test/tests/testpkg.json
+++ b/test/tests/testpkg.json
@@ -1,5 +1,5 @@
 {
-  "main": "./noext",
+  "main": "wrong-main",
   "format": "cjs",
   "defaultExtension": "js",
   "meta": {


### PR DESCRIPTION
This implements a `packagePaths` scheme, which when matched will load a `.json` configuration file to configure the package before proceeding with the package request. This allows packages to be loaded dynamically, without their configuration needing to be present in the SystemJS config file already.