### PR TITLE
Added ability to load resources cross-domain w/ HTTP basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,43 @@
 SystemJS
 ========
 
-[![Build Status][travis-image]][travis-url]
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/systemjs/systemjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
+Important: This fork depends on coordinated changes in "system-fetch.js" in  "https://github.com/ModuleLoader/es6-module-loader", so as things go with this fork calling "npm install" will not pull in the changes from es6-module-loader. The changes in this fork are found in core.js adding the new configuration option "basicAuth". To test though you can take "/dist/system.src.js" and "/dist/system-csp-production.src.js" from this fork directly. The coordinated changes for es6-module-loader can be found in "https://github.com/typhonrt/es6-module-loader".
+
+This is a SystemJS fork adding the ability to pull in modules and other resources cross-domain that require HTTP basic authorization. The necessity for this addition is that I have an unbundled admin domain / site that references modules and resources from the main unbundled development site / domain. Both the admin and developer domain have basic authentication enabled. Since SystemJS uses XMLHttpRequest it's necessary to set authentication headers from the requesting domain (in my case the admin site). To fascilitate this process a new configuration option has been added. "basicAuth" which can contain one or more authentication credentials like the following:
+
+```
+   basicAuth:
+   {
+      "https://private.server.com/": { username: '<USERNAME>', password: '<PASSWORD>' },
+      "https://private.server2.com/": { username: '<USERNAME>', password: '<PASSWORD>' }
+   },
+```
+
+SystemJS when loading resources will add the authentication header with encoded username / password for urls matching the domains provided in the config parameters.
+
+It should be noted that an associated .htaccess file needs to be defined or other web server configuraiton needs to be setup on the private server to be accessed. The following is an example .htaccess file with the relevant details:
+
+```
+AuthType Basic
+AuthUserFile /home/username/private.server.com/.htpasswd
+AuthName "Private"
+<LimitExcept OPTIONS>
+   require valid-user
+</LimitExcept>
+
+Header always add Access-Control-Allow-Origin "https://requesting.domain.com"
+Header always add Access-Control-Allow-Headers "accept, origin, x-requested-with, authorization, content-type"
+Header always add Access-Control-Allow-Methods "GET"
+Header always add Access-Control-Allow-Credentials "true"
+```
+
+I have only tested these changes with Chrome & Safari on OSX. Note, that the above ```<LimitExcept OPTIONS>``` is necessary for Chrome as an OPTIONS request is sent and returned before the actual GET request. 
+
+Please note that the code in this fork has been changed in libs and the make file run, but only the complete source versions of "/dist/system.src.js" and "/dist/system-csp-production.src.js" have the actual changes. The minified and other versions are not modified. Also note the important fact that this modification depends on changes in es6-module-loader as well, so if you run the make file you won't pull in those changes.
+
+Please also note that I'm not a security expert. It seems OK to store the basic authorization credentials in the config.js file for the requesting site. Since in my case I have basic authorization setup for the requesting site the config.js file is not accessible without authentication on the requesting site.  
+
+---------
 
 _For upgrading to SystemJS 0.17 / 0.18, see the [SystemJS 0.17 release upgrade notes for more information](https://github.com/systemjs/systemjs/releases/tag/0.17.0), or read the updated [SystemJS Overview](docs/overview.md) guide._
 

--- a/dist/system-register-only.src.js
+++ b/dist/system-register-only.src.js
@@ -986,7 +986,7 @@ function applyPaths(paths, name) {
   }
 
   var outPath = paths[pathMatch] || name;
-  if (typeof wildcard == 'string')
+  if (wildcard)
     outPath = outPath.replace('*', wildcard);
 
   return outPath;

--- a/lib/core.js
+++ b/lib/core.js
@@ -149,6 +149,15 @@ SystemJSLoader.prototype.config = function(cfg) {
       this.paths[p] = cfg.paths[p];
   }
 
+  if (cfg.basicAuth) {
+    if (typeof this.basicAuth === 'undefined') {
+      this.basicAuth = {};
+    }
+    for (var a in cfg.basicAuth) {
+      this.basicAuth[a] = cfg.basicAuth[a];
+    }
+  }
+
   if (cfg.map) {
     for (var p in cfg.map) {
       var v = cfg.map[p];


### PR DESCRIPTION
Greets...

My 3rd day w/ SystemJS, so I'm new here. I've converted several sites over from RequireJS and I have the need to load modules and resources cross-domain between two unbundled SystemJS distributions that use HTTP basic authentication. Please see the readme as the changes are fully described there. As things go this change requires a change to es6-module-loader and systemjs, so there is a coordinated pull request. I'll also open an issue on the main systemjs to track things together.

The es6-module-loader pull request is here: https://github.com/ModuleLoader/es6-module-loader/pull/431