### PR TITLE
Implement System.version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,24 @@ define POLYFILLS_BANNER
 endef
 export POLYFILLS_BANNER
 
+define STANDARD_VERSION
+
+System.version = '$(VERSION) Standard';
+endef
+export STANDARD_VERSION
+
+define REGISTER_VERSION
+
+System.version = '$(VERSION) Register Only';
+endef
+export REGISTER_VERSION
+
+define CSP_VERSION
+
+System.version = '$(VERSION) CSP';
+endef
+export CSP_VERSION
+
 compile: clean-compile dist/system.src.js dist/system-csp-production.src.js dist/system-register-only.src.js
 build: clean dist/system.js dist/system-csp-production.js dist/system-register-only.js dist/system-polyfills.js
 
@@ -51,89 +69,92 @@ dist/%.js: dist/%.src.js
 	cd dist && ../node_modules/.bin/uglifyjs $(subst dist/,,$<) --compress drop_console --mangle --source-map $*.js.map >> $(subst dist/,,$@) || rm $(subst dist/,,$@)
 
 dist/system.src.js: lib/*.js $(ESML)/*.js
-	@echo "$$BANNER" > $@;
-	cat \
-		lib/wrapper-start.js \
-		$(ESML)/wrapper-start.js \
-			$(ESML)/loader.js \
-			$(ESML)/dynamic-only.js \
-			$(ESML)/system.js \
-			$(ESML)/system-fetch.js \
-			$(ESML)/transpiler.js \
-				lib/global-eval.js \
-				lib/proto.js \
-				lib/core.js \
-				lib/scriptLoader.js \
-				lib/register.js \
-				lib/esm.js \
-				lib/global.js \
-				lib/global-helpers.js \
-				lib/cjs.js \
-				lib/amd-helpers.js \
-				lib/amd.js \
-				lib/map.js \
-				lib/paths.js \
-				lib/package.js \
-				lib/plugins.js \
-				lib/alias.js \
-				lib/meta.js \
-				lib/bundles.js \
-				lib/depCache.js \
-				lib/conditionals.js \
-				lib/createSystem.js \
-		$(ESML)/wrapper-end.js \
-		lib/wrapper-end.js \
-	>> $@;
+	( echo "$$BANNER"; \
+		cat \
+			lib/wrapper-start.js \
+			$(ESML)/wrapper-start.js \
+				$(ESML)/loader.js \
+				$(ESML)/dynamic-only.js \
+				$(ESML)/system.js \
+				$(ESML)/system-fetch.js \
+				$(ESML)/transpiler.js \
+					lib/global-eval.js \
+					lib/proto.js \
+					lib/core.js \
+					lib/scriptLoader.js \
+					lib/register.js \
+					lib/esm.js \
+					lib/global.js \
+					lib/global-helpers.js \
+					lib/cjs.js \
+					lib/amd-helpers.js \
+					lib/amd.js \
+					lib/map.js \
+					lib/paths.js \
+					lib/package.js \
+					lib/plugins.js \
+					lib/alias.js \
+					lib/meta.js \
+					lib/bundles.js \
+					lib/depCache.js \
+					lib/conditionals.js \
+					lib/createSystem.js \
+					; echo "$$STANDARD_VERSION" ; cat \
+			$(ESML)/wrapper-end.js \
+			lib/wrapper-end.js \
+	) > $@;
 
 dist/system-csp-production.src.js: lib/*.js $(ESML)/*.js
-	@echo "$$BANNER" > $@;
-	cat \
-		lib/wrapper-start.js \
-		$(ESML)/wrapper-start.js \
-			$(ESML)/loader.js \
-			$(ESML)/dynamic-only.js \
-			$(ESML)/system.js \
-				lib/proto.js \
-				lib/core.js \
-				lib/scriptLoader.js \
-				lib/scriptOnly.js \
-				lib/register.js \
-				lib/global-helpers.js \
-				lib/amd-helpers.js \
-				lib/map.js \
-				lib/paths.js \
-				lib/package.js \
-				lib/plugins.js \
-				lib/alias.js \
-				lib/meta.js \
-				lib/bundles.js \
-				lib/depCache.js \
-				lib/conditionals.js \
-				lib/createSystem.js \
-		$(ESML)/wrapper-end.js \
-		lib/wrapper-end.js \
-	>> $@;
+	( echo "$$BANNER"; \
+		cat \
+			lib/wrapper-start.js \
+			$(ESML)/wrapper-start.js \
+				$(ESML)/loader.js \
+				$(ESML)/dynamic-only.js \
+				$(ESML)/system.js \
+					lib/proto.js \
+					lib/core.js \
+					lib/scriptLoader.js \
+					lib/scriptOnly.js \
+					lib/register.js \
+					lib/global-helpers.js \
+					lib/amd-helpers.js \
+					lib/map.js \
+					lib/paths.js \
+					lib/package.js \
+					lib/plugins.js \
+					lib/alias.js \
+					lib/meta.js \
+					lib/bundles.js \
+					lib/depCache.js \
+					lib/conditionals.js \
+					lib/createSystem.js \
+					; echo "$$CSP_VERSION" ; cat \
+			$(ESML)/wrapper-end.js \
+			lib/wrapper-end.js \
+	) > $@;
 
 dist/system-register-only.src.js: lib/*.js $(ESML)/*.js
-	@echo "$$BANNER" > $@;
-	cat \
-		$(ESML)/wrapper-start.js \
-			$(ESML)/loader.js \
-			$(ESML)/dynamic-only.js \
-			$(ESML)/system.js \
-			$(ESML)/system-resolve.js \
-				lib/proto.js \
-				lib/scriptLoader.js \
-				lib/scriptOnly.js \
-				lib/register.js \
-				lib/createSystem.js \
-		$(ESML)/wrapper-end.js \
-	>> $@;
+	( echo "$$BANNER"; \
+		cat \
+			$(ESML)/wrapper-start.js \
+				$(ESML)/loader.js \
+				$(ESML)/dynamic-only.js \
+				$(ESML)/system.js \
+				$(ESML)/system-resolve.js \
+					lib/proto.js \
+					lib/scriptLoader.js \
+					lib/scriptOnly.js \
+					lib/register.js \
+					lib/createSystem.js \
+					; echo "$$REGISTER_VERSION" ; cat \
+			$(ESML)/wrapper-end.js \
+	) > $@;
 
 dist/system-polyfills.src.js: lib/*.js $(ESML)/*.js
-	@echo "$$POLYFILLS_BANNER" > $@;
-	cat \
-		$(ESML)/url-polyfill.js \
-		node_modules/when/es6-shim/Promise.js \
-		lib/polyfills-bootstrap.js \
-	>> $@;
+	( echo "$$POLYFILLS_BANNER"; \
+		cat \
+			$(ESML)/url-polyfill.js \
+			node_modules/when/es6-shim/Promise.js \
+			lib/polyfills-bootstrap.js \
+	) > $@;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ if (typeof Promise === 'undefined')
 if (typeof URL === 'undefined')
   require('es6-module-loader/src/url-polyfill');
 
+var version = require('./package.json').version;
+
 var isWindows = process.platform.match(/^win/);
 
 // set transpiler paths in Node
@@ -41,4 +43,8 @@ function SystemJSNodeLoader() {
 SystemJSNodeLoader.prototype = new SystemJSNodeLoaderProto();
 SystemJSNodeLoader.prototype.constructor = SystemJSNodeLoader;
 
-module.exports = global.System = new SystemJSNodeLoader();
+var System = new SystemJSNodeLoader();
+
+System.version = version + ' Node';
+
+module.exports = global.System = System;

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -28,6 +28,11 @@
         });  
       }
 
+      asyncTest('System version', function() {
+        ok(System.version.match(/^\d+\.\d+\.\d+ CSP$/));
+        start();
+      });
+
       asyncTest('Loading an AMD module', function() {
         System['import']('tests/amd-module.js').then(function(m) {
           ok(m.amd == true);

--- a/test/test-register-only.html
+++ b/test/test-register-only.html
@@ -26,7 +26,12 @@
           throw e.stack || e;
           start();
         });  
-      }      
+      }
+
+      asyncTest('System version', function() {
+        ok(System.version.match(/^\d+\.\d+\.\d+ Register Only$/));
+        start();
+      });
 
       asyncTest('System.register Circular', function() {
         System['import']('tests/register-circular1.js').then(function(m) {

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,11 @@ function err(e) {
 
 var ie8 = typeof navigator != 'undefined' && navigator.appVersion && navigator.appVersion.indexOf('MSIE 8') != -1;
 
+asyncTest('System version', function() {
+  ok(System.version.match(/^\d+\.\d+\.\d+ Standard$/));
+  start();
+});
+
 asyncTest('new Module().toString() == "Module"', function() {
   System['import']('tests/global.js').then(function() {
     var m = System.get(System.normalizeSync('tests/global.js'));

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ function err(e) {
 var ie8 = typeof navigator != 'undefined' && navigator.appVersion && navigator.appVersion.indexOf('MSIE 8') != -1;
 
 asyncTest('System version', function() {
-  ok(System.version.match(/^\d+\.\d+\.\d+ Standard$/));
+  ok(System.version.match(/^\d+\.\d+\.\d+ (Standard|Node)$/));
   start();
 });
 


### PR DESCRIPTION
This would probably be useful to have...

`System.version` version strings output are:

* `"0.18.17 Standard"` - for the normal system.js build
* `"0.18.17 CSP"` - for the system-csp build
* `"0.18.17 Register Only"` for the register-only build
* `"0.18.17 Node"` - when running in NodeJS