### PR TITLE
detect if we're running in a node browser (e.g. jsdom)

### DIFF
--- a/lib/global-eval.js
+++ b/lib/global-eval.js
@@ -30,7 +30,7 @@ var __exec;
 
   // Web Worker and Chrome Extensions use original ESML eval
   // this may lead to some global module execution differences (eg var not defining onto global)
-  if (isWorker || isBrowser && window.chrome && window.chrome.extension) {
+  if (isWorker || isBrowser && window.chrome && window.chrome.extension || isBrowser && typeof process != 'undefined' && typeof process.versions != 'undefined' && typeof process.versions.node != 'undefined') {
     __exec = function(load) {
       try {
         preExec(this);


### PR DESCRIPTION
As discussed in #821, this PR address the detection of node browsers like jsdom that should be treated differently than a "normal" browser.

fix #821 