### PR TITLE
Fix for alias meta in package config

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -23,6 +23,8 @@
             setters: [function(module) {
               for (var p in module)
                 _export(p, module[p]);
+              if (module.__useDefault)
+                entry.module.exports.__useDefault = true;
             }],
             execute: function() {}
           };

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -14,18 +14,18 @@
       var aliasDeps = load.metadata.deps || [];
       if (alias) {
         load.metadata.format = 'defined';
-        this.defined[load.name] = {
-          declarative: true,
-          deps: aliasDeps.concat([alias]),
-          declare: function(_export) {
-            return {
-              setters: [function(module) {
-                for (var p in module)
-                  _export(p, module[p]);
-              }],
-              execute: function() {}
-            };
-          }
+        var entry = createEntry();
+        this.defined[load.name] = entry;
+        entry.declarative = true;
+        entry.deps = aliasDeps.concat([alias]);
+        entry.declare = function(_export) {
+          return {
+            setters: [function(module) {
+              for (var p in module)
+                _export(p, module[p]);
+            }],
+            execute: function() {}
+          };
         };
         return '';
       }

--- a/test/test.js
+++ b/test/test.js
@@ -1104,19 +1104,19 @@ if (typeof process != 'undefined') {
 asyncTest('Package-local alias esm', function() {
   System.config({
     map: {
-      'package-local-alias': 'tests/package-local-alias'
+      'package-local-alias-esm': 'tests/package-local-alias'
     },
     packages: {
-      'package-local-alias': {
+      'package-local-alias-esm': {
         main: 'index-esm.js',
         format: 'esm',
         meta: {
-          './local': {alias: './local/index-esm.js'}
+          './local-esm': {alias: './local/index-esm.js'}
         }
       }
     }
   });
-  System['import']('package-local-alias').then(function(m) {
+  System['import']('package-local-alias-esm').then(function(m) {
     ok(m.q == 'q');
     ok(m.fromLocal == 'x');
     start();
@@ -1126,23 +1126,71 @@ asyncTest('Package-local alias esm', function() {
 asyncTest('Package-local alias cjs', function() {
   System.config({
     map: {
-      'package-local-alias': 'tests/package-local-alias'
+      'package-local-alias-cjs': 'tests/package-local-alias'
     },
     packages: {
-      'package-local-alias': {
+      'package-local-alias-cjs': {
         main: 'index-cjs.js',
         format: 'cjs',
         meta: {
-          './local': {alias: './local/index-cjs.js'}
+          './local-cjs': {alias: './local/index-cjs.js'}
         }
       }
     }
   });
-  System['import']('package-local-alias').then(function(m) {
+  System['import']('package-local-alias-cjs').then(function(m) {
     ok(m.q == 'q');
     ok(m.fromLocal == 'x');
     start();
   });
 });
+  
+asyncTest('Package-local alias esm default export', function() {
+  System.config({
+    map: {
+      'package-local-alias-default-esm': 'tests/package-local-alias'
+    },
+    packages: {
+      'package-local-alias-default-esm': {  // can't reuse package names from previous test
+        main: 'index-default-esm.js',   // because System.config() results persist across tests
+        format: 'esm',
+        meta: {
+          './local-default-esm': {alias: './local/index-default-esm.js'}
+        }
+      }
+    }
+  });
+  System['import']('package-local-alias-default-esm').then(function(m) {
+    ok(m.q == 'q');
+    ok(m.fromLocal == 'x');
+    ok(m.fromLocalDirect == 'x');
+    start();
+  });
+});
+
+asyncTest('Package-local alias cjs default export', function() {
+  System.config({
+    map: {
+      'package-local-alias-default-cjs': 'tests/package-local-alias'
+    },
+    packages: {
+      'package-local-alias-default-cjs': {
+        main: 'index-default-cjs.js',
+        format: 'cjs',
+        meta: {
+          './local-default-cjs': {alias: './local/index-default-cjs.js'}
+        }
+      }
+    }
+  });
+  System['import']('package-local-alias-default-cjs').then(function(m) {
+    ok(m.q == 'q');
+    ok(m.fromLocal == 'x'); 
+    ok(m.fromLocalDirect == 'x');
+    start();
+  });
+});
+
+
 
 })(typeof window == 'undefined' ? global : window);

--- a/test/test.js
+++ b/test/test.js
@@ -1100,5 +1100,49 @@ if (typeof process != 'undefined') {
     start();
   });
 }
+  
+asyncTest('Package-local alias esm', function() {
+  System.config({
+    map: {
+      'package-local-alias': 'tests/package-local-alias'
+    },
+    packages: {
+      'package-local-alias': {
+        main: 'index-esm.js',
+        format: 'esm',
+        meta: {
+          './local': {alias: './local/index-esm.js'}
+        }
+      }
+    }
+  });
+  System['import']('package-local-alias').then(function(m) {
+    ok(m.q == 'q');
+    ok(m.fromLocal == 'x');
+    start();
+  });
+});
+
+asyncTest('Package-local alias cjs', function() {
+  System.config({
+    map: {
+      'package-local-alias': 'tests/package-local-alias'
+    },
+    packages: {
+      'package-local-alias': {
+        main: 'index-cjs.js',
+        format: 'cjs',
+        meta: {
+          './local': {alias: './local/index-cjs.js'}
+        }
+      }
+    }
+  });
+  System['import']('package-local-alias').then(function(m) {
+    ok(m.q == 'q');
+    ok(m.fromLocal == 'x');
+    start();
+  });
+});
 
 })(typeof window == 'undefined' ? global : window);

--- a/test/tests/package-local-alias/index-cjs.js
+++ b/test/tests/package-local-alias/index-cjs.js
@@ -1,0 +1,6 @@
+
+var local = require('./local');
+
+exports.q = 'q';
+
+exports.fromLocal = local.x;

--- a/test/tests/package-local-alias/index-cjs.js
+++ b/test/tests/package-local-alias/index-cjs.js
@@ -1,5 +1,5 @@
 
-var local = require('./local');
+var local = require('./local-cjs');
 
 exports.q = 'q';
 

--- a/test/tests/package-local-alias/index-default-cjs.js
+++ b/test/tests/package-local-alias/index-default-cjs.js
@@ -1,0 +1,10 @@
+
+var local = require('./local-default-cjs');
+
+exports.q = 'q';
+
+exports.fromLocal = local;
+
+var localDirect = require('./local/index-default-cjs.js');
+
+exports.fromLocalDirect = localDirect;

--- a/test/tests/package-local-alias/index-default-esm.js
+++ b/test/tests/package-local-alias/index-default-esm.js
@@ -1,0 +1,10 @@
+
+import local from './local-default-esm';
+
+export var q = 'q';
+export var fromLocal = local;
+
+import localDirect from './local/index-default-esm.js';
+
+export var fromLocalDirect = localDirect;
+

--- a/test/tests/package-local-alias/index-esm.js
+++ b/test/tests/package-local-alias/index-esm.js
@@ -1,0 +1,5 @@
+
+import {x} from './local';
+
+export var q = 'q';
+export var fromLocal = x;

--- a/test/tests/package-local-alias/index-esm.js
+++ b/test/tests/package-local-alias/index-esm.js
@@ -1,5 +1,5 @@
 
-import {x} from './local';
+import {x} from './local-esm';
 
 export var q = 'q';
 export var fromLocal = x;

--- a/test/tests/package-local-alias/local/index-cjs.js
+++ b/test/tests/package-local-alias/local/index-cjs.js
@@ -1,0 +1,1 @@
+exports.x = 'x';

--- a/test/tests/package-local-alias/local/index-default-cjs.js
+++ b/test/tests/package-local-alias/local/index-default-cjs.js
@@ -1,0 +1,1 @@
+module.exports = 'x';

--- a/test/tests/package-local-alias/local/index-default-esm.js
+++ b/test/tests/package-local-alias/local/index-default-esm.js
@@ -1,0 +1,2 @@
+
+export default 'x';

--- a/test/tests/package-local-alias/local/index-esm.js
+++ b/test/tests/package-local-alias/local/index-esm.js
@@ -1,0 +1,1 @@
+export var x = 'x';


### PR DESCRIPTION
This fixes a bug I encountered while trying to use meta : {alias : ... } in package config - groupIndex was left uninitialized in the entry created in alias.js, which in my case lead to buildGroups producing groups 'array' with two indices: 0 and NaN