### PR TITLE
Pass the load address to the loader normalizer

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -551,7 +551,7 @@ function createEntry() {
       // first, normalize all dependencies
       var normalizePromises = [];
       for (var i = 0, l = entry.deps.length; i < l; i++)
-        normalizePromises.push(Promise.resolve(loader.normalize(entry.deps[i], load.name)));
+        normalizePromises.push(Promise.resolve(loader.normalize(entry.deps[i], load.name, load.address)));
 
       return Promise.all(normalizePromises).then(function(normalizedDeps) {
 


### PR DESCRIPTION
Is the a reason that the address is not already included by default?