### PR TITLE
packageConfigPaths with defaultJSExtentions=true still broken in 0.19.12

### DIFF
--- a/dist/system.src.js
+++ b/dist/system.src.js
@@ -1832,8 +1832,6 @@ SystemJSLoader.prototype.config = function(cfg) {
       var packageLength = Math.max(path.lastIndexOf('*') + 1, path.lastIndexOf('/'));
       var normalized = loader.decanonicalize(path.substr(0, packageLength) + '/');
       normalized = normalized.substr(0, normalized.length - 1) + path.substr(packageLength);
-      if (loader.defaultJSExtensions && path.substr(path.length - 3, 3) != '.js')
-        normalized = normalized.substr(0, normalized.length - 3);
       packageConfigPaths[i] = normalized;
     }
     loader.packageConfigPaths = packageConfigPaths;


### PR DESCRIPTION
When I use packageConfigPaths it I get 
[Wed, 06 Jan 2016 21:17:14 GMT] "GET /node_modules/angular2/package.j" Error (404): "Not found"
[Wed, 06 Jan 2016 21:17:14 GMT] "GET /node_modules/angular2-jwt/package.j" Error (404): "Not found"

these two lines seems to be the fault:
```javascript
      if (loader.defaultJSExtensions && path.substr(path.length - 3, 3) != '.js')
        normalized = normalized.substr(0, normalized.length - 3);
```
seems unnecessary for packageConfigPaths (since they are never js files, always json files).

you can look at the same repository for reproduction
https://github.com/ronzeidman/open-ng2-tests