### PR TITLE
Add plugin-lazyimage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Additional Plugins:
 
 * [Audio](https://github.com/ozsay/plugin-audio) `System.import('./beep.mp3!audio')`
 * [CoffeeScript](https://github.com/forresto/plugin-coffee) `System.import('./test.coffee')`
+* [Image (lazy)](https://github.com/laurentgoudet/plugin-lazyimage) Async plugin-image
 * [Jade](https://github.com/johnsoftek/plugin-jade)
 * [Jade VirtualDOM](https://github.com/WorldMaker/system-jade-virtualdom)
 * [JSX](https://github.com/floatdrop/plugin-jsx) `System.import('template.jsx')`


### PR DESCRIPTION
I had the use case of creating a lazy version of [plugin-image](https://github.com/systemjs/plugin-image) to improve the page load time of a page with a carousel. Using SystemJS plugins is nice as it ties the code implementing the behavior, here the carousel, with the assets needed (the images and/or the css). However, plugin-image was blocking the carousel code to be executed until all the images were fully loaded. Using `System.import`s instead of `import`s would have only solved half of the issue, since it returns only when the images are fully loaded (no progressive rendering), and the module's dependencies can't be statically traced anymore (which I use to detect unused files). Please advice if there's a better approach.