### PR TITLE
Stop globals injection obscuring 'use strict' for cjs (#1109)

### DIFF
--- a/dist/system-csp-production.src.js
+++ b/dist/system-csp-production.src.js
@@ -38,10 +38,13 @@ function bootstrap() {(function(__global) {
   })();
 
   function addToError(err, msg) {
-    if (err instanceof Error)
-      err.message = err.message + '\n\t' + msg;
-    else
-      err += '\n\t' + msg;
+    if (err instanceof Error) {
+      err.message = msg + '\n\t' + err.message;
+      Error.call(err, err.message);
+    }
+    else {
+      err = msg + '\n\t' + err;
+    }
     return err;
   }
 
@@ -2925,7 +2928,12 @@ function createEntry() {
           continue;
         return getModule(entry.normalizedDeps[i], loader);
       }
-      throw new Error('Module ' + name + ' not declared as a dependency.');
+      // try and normalize the dependency to see if we have another form
+      var nameNormalized = loader.normalizeSync(name, entry.name);
+      if (indexOf.call(entry.normalizedDeps, nameNormalized) != -1)
+        return getModule(nameNormalized, loader);
+
+      throw new Error('Module ' + name + ' not declared as a dependency of ' + entry.name);
     }, exports, module);
     
     if (output)

--- a/dist/system-register-only.src.js
+++ b/dist/system-register-only.src.js
@@ -37,10 +37,13 @@
   })();
 
   function addToError(err, msg) {
-    if (err instanceof Error)
-      err.message = err.message + '\n\t' + msg;
-    else
-      err += '\n\t' + msg;
+    if (err instanceof Error) {
+      err.message = msg + '\n\t' + err.message;
+      Error.call(err, err.message);
+    }
+    else {
+      err = msg + '\n\t' + err;
+    }
     return err;
   }
 
@@ -1740,7 +1743,12 @@ function createEntry() {
           continue;
         return getModule(entry.normalizedDeps[i], loader);
       }
-      throw new Error('Module ' + name + ' not declared as a dependency.');
+      // try and normalize the dependency to see if we have another form
+      var nameNormalized = loader.normalizeSync(name, entry.name);
+      if (indexOf.call(entry.normalizedDeps, nameNormalized) != -1)
+        return getModule(nameNormalized, loader);
+
+      throw new Error('Module ' + name + ' not declared as a dependency of ' + entry.name);
     }, exports, module);
     
     if (output)

--- a/lib/cjs.js
+++ b/lib/cjs.js
@@ -10,6 +10,8 @@
   var commentRegEx = /(^|[^\\])(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
 
   var stringRegEx = /("[^"\\\n\r]*(\\.[^"\\\n\r]*)*"|'[^'\\\n\r]*(\\.[^'\\\n\r]*)*')/g;
+  // match "use strict" as long as it isn't after a function declaration
+  var strictRegEx = /(?:('use strict'|"use strict");?\s*\n)(?=[^]*function[^]*)/g;
 
   function getCJSDeps(source) {
     cjsRequireRegEx.lastIndex = commentRegEx.lastIndex = stringRegEx.lastIndex = 0;
@@ -108,8 +110,11 @@
             for (var g in load.metadata.globals)
               globals += 'var ' + g + ' = require("' + load.metadata.globals[g] + '");';
           }
-
-          load.source = "(function(require, exports, module, __filename, __dirname, global, GLOBAL) {" + globals
+          var strict = '';
+          if (strictRegEx.exec(load.source)) {
+            strict = '"use strict";';
+          }
+          load.source = "(function(require, exports, module, __filename, __dirname, global, GLOBAL) {" + strict + globals
               + load.source + "\n}).apply(__cjsWrapper.exports, __cjsWrapper.args);";
 
           __exec.call(loader, load);


### PR DESCRIPTION
Hi Guy, 

I'm not sure if this is how you intended to fix it, or if the regex is comprehensive enough. However, it seems to succeed identifying a global "use strict" statement whilst ignoring one inside a function body.

I'm slightly confused that running `make` shows not all existing changes have been built to the dist directory. I didn't bother commiting a `make build` version as I wonder if this is intentional.

Thanks,

Tom