### PR TITLE
Stop globals injection obscuring 'use strict' for commonjs

### DIFF
--- a/lib/cjs.js
+++ b/lib/cjs.js
@@ -10,6 +10,8 @@
   var commentRegEx = /(^|[^\\])(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
 
   var stringRegEx = /("[^"\\\n\r]*(\\.[^"\\\n\r]*)*"|'[^'\\\n\r]*(\\.[^'\\\n\r]*)*')/g;
+  // match "use strict" as long as it isn't after a function declaration
+  var strictRegEx = /((?:function[^]+?)?)('use strict'|"use strict")+/g;
 
   function getCJSDeps(source) {
     cjsRequireRegEx.lastIndex = commentRegEx.lastIndex = stringRegEx.lastIndex = 0;
@@ -109,7 +111,14 @@
               globals += 'var ' + g + ' = require("' + load.metadata.globals[g] + '");';
           }
 
-          load.source = "(function(require, exports, module, __filename, __dirname, global, GLOBAL) {" + globals
+          var strict = '';
+          while (match = strictRegEx.exec(load.source)) {
+            if (match[2].slice(1, -1) === 'use strict' && match[1] === '') {
+              strict = '"use strict";';
+            }
+          }
+										   + ""
+          load.source = "(function(require, exports, module, __filename, __dirname, global, GLOBAL) {" + strict + globals
               + load.source + "\n}).apply(__cjsWrapper.exports, __cjsWrapper.args);";
 
           __exec.call(loader, load);


### PR DESCRIPTION
Apologies, my previous regex was incorrect. This approach should work so long as the word "function" isn't included in a comment above the "use strict" declaration.