### PR TITLE
added `crossOrigin` meta option

### DIFF
--- a/docs/config-api.md
+++ b/docs/config-api.md
@@ -190,10 +190,19 @@ System.config({
   Set a loader for this meta path.
 * [`sourceMap`](creating-plugins.md):
   For plugin transpilers to set the source map of their transpilation.
+* `scriptLoad`: Load the module using `<script>` tag injection.
 * `nonce`: The [nonce](https://www.w3.org/TR/CSP2/#script-src-the-nonce-attribute) attribute to use when loading the script as a way to enable CSP.
   This should correspond to the "nonce-" attribute set in the Content-Security-Policy header.
 * `integrity`: The [subresource integrity](http://www.w3.org/TR/SRI/#the-integrity-attribute) attribute corresponding to the script integrity, describing the expected hash of the final code to be executed.
   For example, `System.config({ meta: { 'src/example.js': { integrity: 'sha256-e3b0c44...' }});` would throw an error if the translated source of `src/example.js` doesn't match the expected hash.
+* `crossOrigin`: When scripts are loaded from a different domain (e.g. CDN) the global error handler (`window.onerror`)
+  has very limited information about errors to [prevent unintended leaking]
+  (https://developer.mozilla.org/en/docs/Web/API/GlobalEventHandlers/onerror#Notes).
+  In order to mitigate this, the `<script>` tags need to set [`crossorigin` attribute]
+  (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin) and the server needs to
+  [enable CORS](http://enable-cors.org/).
+  The [valid values](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) are 
+  `"anonymous"` and `"use-credentials"`.
 * `esmExports`: When loading a module that is not an ECMAScript Module, we set the module as the `default` export, but then also 
   iterate the module object and copy named exports for it a well. Use this option to disable this iteration and copying of the exports.
 

--- a/lib/scriptLoader.js
+++ b/lib/scriptLoader.js
@@ -111,7 +111,10 @@
         var s = document.createElement('script');
         
         s.async = true;
-        
+
+        if (load.metadata.crossOrigin)
+          s.crossOrigin = load.metadata.crossOrigin;
+
         if (load.metadata.integrity)
           s.setAttribute('integrity', load.metadata.integrity);
 


### PR DESCRIPTION
We're hosting our static files on a CDN, so we're often faced with limitations of [Same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). One of such limitations is that scripts loaded from a different domain don't provide [extended error information](https://developer.mozilla.org/en/docs/Web/API/GlobalEventHandlers/onerror#Notes) when an exception is thrown. All you get is `"Script error."` message and nothing else.

When combined with `scriptLoad`, the `crossOrigin` option allows to set [additional property](https://developer.mozilla.org/en/docs/Web/API/HTMLScriptElement#crossOrigin_property) on the script element to allow rich error reporting for scripts loaded from a different origin.

```js
  meta: {
    "*.js": {
      format: "register",
      scriptLoad: true,
      crossOrigin: "anonymous"
    }
  }
```

Here's a related discussion in the RequireJS repo: https://github.com/jrburke/requirejs/issues/687