### PR TITLE
Safe concat in case deps is undefined.

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -516,14 +516,14 @@ function createEntry() {
         entry = loader.defined[load.name];
         // don't support deps for ES modules
         if (!entry.declarative)
-          entry.deps = entry.deps.concat(load.metadata.deps);
+          entry.deps = entry.deps.concat(load.metadata.deps || []);
       }
 
       // picked up already by an anonymous System.register script injection
       // or via the dynamic formats
       else if (load.metadata.entry) {
         entry = load.metadata.entry;
-        entry.deps = entry.deps.concat(load.metadata.deps);
+        entry.deps = entry.deps.concat(load.metadata.deps || []);
       }
 
       // Contains System.register calls
@@ -541,7 +541,7 @@ function createEntry() {
 
         // support metadata deps for System.register
         if (entry && load.metadata.deps)
-          entry.deps = entry.deps.concat(load.metadata.deps);
+          entry.deps = entry.deps.concat(load.metadata.deps || []);
       }
 
       // named bundles are just an empty module


### PR DESCRIPTION
I was experimenting with a caching translate hook plugin and found that if I skipped the default translate call (returning something cached instead) then I got an error on some of the CSS dependencies.  The error turned out to be due to array concatenation in the `instantiate` hook in `register.js`.  In several places, it uses `entry.deps.concat(load.metadata.deps)` which results in `[undefined]` if `load.metadata.deps` happens to be undefined.  The undefined dependency name then breaks things downstream.

I'm not sure what exactly is going on with `metadata.deps`, but if there's a chance that it might not get initialized (assuming it's not my fault for abusing a loader hook) then it would be safest to default to `[]`.