### PR TITLE
getMetaMatches should check for own property

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -570,7 +570,7 @@
       }
     }
     // exact meta
-    var exactMeta = pkgMeta[subPath] || pkgMeta['./' + subPath];
+    var exactMeta = pkgMeta.hasOwnProperty(subPath) && pkgMeta[subPath] || pkgMeta['./' + subPath];
     if (exactMeta)
       matchFn(exactMeta, exactMeta, 0);
   }


### PR DESCRIPTION
I was experimenting with lodash-es in jspm 0.17 and getting 404 errors on:
```
http://localhost:8080/jspm_packages/npm/lodash-es@4.6.1/valueOf
http://localhost:8080/jspm_packages/npm/lodash-es@4.6.1/toString
```
with:
```
  "jspm": {
    "dependencies": {
      "lodash-es": "npm:lodash-es@^4.6.1"
    },
    "overrides": {
      "npm:lodash-es@4.6.1": {
        "format": "esm",
        "defaultExtension": "js"
      }
    }
  }
```
This was really strange because the dozens of other subPaths coming in from lodash were resolved to the actual `.js` file fine.  I did some stepping and found:
```
var exactMeta = pkgMeta[subPath] || pkgMeta['./' + subPath];
```
Which is going to work for *most* cases, but not for prototypal properties `toString` and `valueOf`.