### PR TITLE
Fix "Source Maps are off"

### DIFF
--- a/lib/global-eval.js
+++ b/lib/global-eval.js
@@ -17,9 +17,6 @@ var __exec;
       if (typeof sourceMap != 'object')
         throw new TypeError('load.metadata.sourceMap must be set to an object.');
 
-      if (sourceMap.mappings)
-        sourceMap.mappings = ';' + sourceMap.mappings;
-
       sourceMap = JSON.stringify(sourceMap);
     }
 


### PR DESCRIPTION
We don't add new line in the beginning of the file to avoid one line offset issue. So we must not change existing source mappings.

See https://github.com/frankwallis/plugin-typescript/issues/110#issuecomment-201242615