### PR TITLE
Fixing #1192. Falling back to normal way of setting properties when getOwnPropertyDescriptor throws

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -63,15 +63,20 @@ function getESModule(exports) {
   if (typeof exports == 'object' || typeof exports == 'function') {
     if (getOwnPropertyDescriptor) {
       var d;
-      for (var p in exports)
-        if (d = Object.getOwnPropertyDescriptor(exports, p))
-          defineProperty(esModule, p, d);
+      for (var p in exports) {
+        try {
+          if (d = Object.getOwnPropertyDescriptor(exports, p))
+            defineProperty(esModule, p, d);
+        } catch (ex) {
+          // Object.getOwnPropertyDescriptor threw an exception, fall back to normal set property.
+          normalSetProperty(esModule, exports, p);
+        }
+      }
     }
     else {
       var hasOwnProperty = exports && exports.hasOwnProperty;
       for (var p in exports) {
-        if (!hasOwnProperty || exports.hasOwnProperty(p))
-          esModule[p] = exports[p];
+        normalSetProperty(esModule, exports, p);
       }
     }
   }
@@ -80,6 +85,11 @@ function getESModule(exports) {
     value: true
   });
   return esModule;
+
+  function normalSetProperty(targetObj, sourceObj, propName) {
+    if (!hasOwnProperty || sourceObj.hasOwnProperty(p))
+      targetObj[propName] = sourceObj[propName];
+  }
 }
 
 function extend(a, b, prepend) {

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -61,23 +61,16 @@ function getESModule(exports) {
   var esModule = {};
   // don't trigger getters/setters in environments that support them
   if (typeof exports == 'object' || typeof exports == 'function') {
+    var hasOwnProperty = exports && exports.hasOwnProperty;
     if (getOwnPropertyDescriptor) {
-      var d;
       for (var p in exports) {
-        try {
-          if (d = Object.getOwnPropertyDescriptor(exports, p))
-            defineProperty(esModule, p, d);
-        } catch (ex) {
-          // Object.getOwnPropertyDescriptor threw an exception, fall back to normal set property.
-          normalSetProperty(esModule, exports, p);
-        }
+        if (!trySilentDefineProperty(esModule, exports, p))
+          setPropertyIfHasOwnProperty(esModule, exports, p, hasOwnProperty);
       }
     }
     else {
-      var hasOwnProperty = exports && exports.hasOwnProperty;
-      for (var p in exports) {
-        normalSetProperty(esModule, exports, p);
-      }
+      for (var p in exports)
+        setPropertyIfHasOwnProperty(esModule, exports, p, hasOwnProperty);
     }
   }
   esModule['default'] = exports;
@@ -85,10 +78,23 @@ function getESModule(exports) {
     value: true
   });
   return esModule;
+}
 
-  function normalSetProperty(targetObj, sourceObj, propName) {
-    if (!hasOwnProperty || sourceObj.hasOwnProperty(p))
-      targetObj[propName] = sourceObj[propName];
+function setPropertyIfHasOwnProperty(targetObj, sourceObj, propName, hasOwnProperty) {
+  if (!hasOwnProperty || sourceObj.hasOwnProperty(propName))
+    targetObj[propName] = sourceObj[propName];
+}
+
+function trySilentDefineProperty(targetObj, sourceObj, propName) {
+  try {
+    var d;
+    if (d = Object.getOwnPropertyDescriptor(sourceObj, propName))
+      defineProperty(targetObj, propName, d);
+
+    return true;
+  } catch (ex) {
+    // Object.getOwnPropertyDescriptor threw an exception, fall back to normal set property.
+    return false;
   }
 }
 


### PR DESCRIPTION
See #1192 for an explanation of the bug this fixes. My solution is to be defensive when calling `Object.getOwnPropertyDescriptor`, falling back to just setting the property normally when `getOwnPropertyDescriptor` throws (even though a `setter` is potentially being fired). I didn't dive deep enough into the code to find out how hard it would be to write a test for this use case, but I did test this locally and saw that my app, that was unable to bootstrap in IE11 without this code, is now able to properly bootstrap. Let me know if there's a good way to write a test for it though.

Also, assuming that this is merged, when could I hope for it to be published to npm? The company I work for is hoping to launch a new product in about next two weeks, and I'd rather not have to deploy my fork of systemjs (and probably a forked jspm pointing to my systemjs, too??) to production.