### PR TITLE
Update to add alternative sass/scss plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Additional Plugins:
 * [Markdown](https://github.com/guybedford/plugin-md)
 * [raw](https://github.com/matthewbauer/plugin-raw)
 * [SASS](https://github.com/screendriver/plugin-sass)
+* [SCSS](https://github.com/kevcjones/plugin-scss)
 * [sofe](https://github.com/CanopyTax/sofe)
 * [SVG](https://github.com/vuzonp/systemjs-plugin-svg)
 * [WebFont](https://github.com/guybedford/plugin-font)


### PR DESCRIPTION
Just putting this out there, an alternative sass/scss plugin, born from needing to capture the CSS output and inject where you want, not the 'head', e.g. Angular 2's @Component style attribute.