### PR TITLE
Only include actively used files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   },
   "author": "Guy Bedford",
   "license": "MIT",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "dependencies": {
     "when": "^3.7.5"
   },


### PR DESCRIPTION
The npm package includes a whole bunch of things that seem not to be used for neither browser usage or node usage. Mainly `test` and `lib` seem to be unneeded in the distributed package, and of course all the project files.

This PR adds a white listed array of files to include in the npm package.

Before:
```
systemjs-0.19.26.tgz
package/package.json
package/.npmignore
package/README.md
package/LICENSE
package/index.js
package/bower.json
package/.agignore
package/dist/system-csp-production.js
package/dist/system-csp-production.src.js
package/dist/system-polyfills.js
package/dist/system.js
package/dist/system-polyfills.src.js
package/dist/system-register-only.src.js
package/dist/system.src.js
package/dist/system-register-only.js
package/dist/system-register-only.js.map
package/dist/system-csp-production.js.map
package/dist/system-polyfills.js.map
package/dist/system.js.map
package/docs/config-api.md
package/docs/creating-plugins.md
package/docs/es6-modules-overview.md
package/docs/module-formats.md
package/docs/overview.md
package/docs/production-workflows.md
package/docs/system-api.md
package/Makefile
package/lib/alias.js
package/lib/createSystem.js
package/lib/depCache.js
package/lib/esm.js
package/lib/global-eval.js
package/lib/core.js
package/lib/global.js
package/lib/meta.js
package/lib/package.js
package/lib/plugins.js
package/lib/polyfills-bootstrap.js
package/lib/conditionals.js
package/lib/proto.js
package/lib/cjs.js
package/lib/register.js
package/lib/cjs-helpers.js
package/lib/scriptLoader.js
package/lib/bundles.js
package/lib/scriptOnly.js
package/lib/amd.js
package/lib/wrapper-end.js
package/lib/amd-helpers.js
package/lib/wrapper-start.js
package/lib/global-helpers.js
package/.travis.yml
package/test/test-babel.js
package/test/test-traceur.js
package/test/test-typescript.js
package/test/test.js
package/test/test-tracer.html
package/test/test-jsextensions.html
package/test/test-register-only.html
package/test/test-babel.html
package/test/test-traceur-runtime.html
package/test/test-traceur.html
package/test/test-babel-runtime.html
package/test/test-typescript.html
package/test/test-csp-inline.html
package/test/test-csp.html
package/test/tests/#.js
package/test/tests/default1-dep.js
package/test/tests/default1.js
package/test/tests/default2.js
package/test/tests/umd.js
package/test/tests/dep.js
package/test/tests/umd-dep.js
package/test/tests/eaa-amd.js
package/test/tests/eaa-es6.js
package/test/tests/empty-es6.js
package/test/tests/css.js
package/test/tests/subcontextual-mapdep.js
package/test/tests/versioned@2.0.3.js
package/test/tests/error-loader.js
package/test/tests/with-global-deps.js
package/test/tests/error-loader2.js
package/test/tests/cs-loader.js
package/test/tests/error.js
package/test/tests/with-runtime-babel.js
package/test/tests/es-module-flag.js
package/test/tests/with-runtime-traceur.js
package/test/tests/es-named-import-cjs-cjs.js
package/test/tests/contextual-map-dep.js
package/test/tests/es-named-import-cjs.js
package/test/tests/worker-babel.js
package/test/tests/es6-and-amd.js
package/test/tests/worker-traceur.js
package/test/tests/es6-circular1.js
package/test/tests/compiler-plugin.js
package/test/tests/advanced-plugin.js
package/test/tests/worker-typescript.js
package/test/tests/es6-cjs-named-export.js
package/test/tests/commonjs-variation2.js
package/test/tests/es6-detection1.js
package/test/tests/commonjs-variation.js
package/test/tests/es6-format.js
package/test/tests/commonjs-requires.js
package/test/tests/es6-import-star-amd.js
package/test/tests/commonjs-globals.js
package/test/tests/es6-loading-amd-dep.js
package/test/tests/commonjs-d2.js
package/test/tests/es6-loading-amd.js
package/test/tests/commonjs-d.js
package/test/tests/es6-plugin.js
package/test/tests/common-js-module.js
package/test/tests/export-star.js
package/test/tests/common-js-dep.js
package/test/tests/foo.js
package/test/tests/cjs-this.js
package/test/tests/global-dep.js
package/test/tests/cjs-resolve.js
package/test/tests/global-exports-array.js
package/test/tests/cjs-process.js
package/test/tests/global-inaccessible-props.js
package/test/tests/cjs-named-export.js
package/test/tests/global-inline-dep.js
package/test/tests/cjs-module-bom.js
package/test/tests/global-inline-export.js
package/test/tests/cjs-loading-plugin.js
package/test/tests/global-multi-diff.js
package/test/tests/cjs-globals.js
package/test/tests/global-multi.js
package/test/tests/cjs-format.js
package/test/tests/global-shim-amd.js
package/test/tests/cjs-exports.js
package/test/tests/global-shim-config-dep.js
package/test/tests/cjs-exports-dep.js
package/test/tests/global-shim-config-exports.js
package/test/tests/cjs-exports-bom.js
package/test/tests/global-shim-config.js
package/test/tests/cjs-circular2.js
package/test/tests/global-single.js
package/test/tests/cjs-circular1.js
package/test/tests/global-with-export.js
package/test/tests/bundle.js
package/test/tests/global.js
package/test/tests/branch-ie.js
package/test/tests/group-test.js
package/test/tests/branch-boolean.js
package/test/tests/star-dep.js
package/test/tests/wrapper.js
package/test/tests/inline-depends-dep.js
package/test/tests/async.js
package/test/tests/inline-depends.js
package/test/tests/anon-named.js
package/test/tests/jquery-named.js
package/test/tests/amd-simplified-cjs-aliased-require2.js
package/test/tests/legacy-plugin.js
package/test/tests/amd-simplified-cjs-aliased-require1.js
package/test/tests/main-bundle.js
package/test/tests/amd-require.js
package/test/tests/main-dep.js
package/test/tests/amd-module.js
package/test/tests/main.js
package/test/tests/amd-module-bom.js
package/test/tests/shim-map-test-dep.js
package/test/tests/amd-module-3.js
package/test/tests/map-test-dep.js
package/test/tests/amd-module-2.js
package/test/tests/map-test.js
package/test/tests/amd-format.js
package/test/tests/map-version.js
package/test/tests/amd-extra-deps.js
package/test/tests/meta-deps.js
package/test/tests/amd-dynamic.js
package/test/tests/meta-override.js
package/test/tests/amd-dynamic-require.js
package/test/tests/mixed-bundle.js
package/test/tests/amd-dep.js
package/test/tests/module-name.js
package/test/tests/amd-dep-B.js
package/test/tests/module.js
package/test/tests/amd-dep-A.js
package/test/tests/multiple-anonymous.js
package/test/tests/amd-contextual.js
package/test/tests/reldynamicdep.js
package/test/tests/amd-cjs-module.js
package/test/tests/nameddefine.js
package/test/tests/amd-circular2.js
package/test/tests/reldynamic.js
package/test/tests/amd-circular1.js
package/test/tests/normalize-hook-test.js
package/test/tests/amd-bundle.js
package/test/tests/registerdynamic-notbundled.js
package/test/tests/all-layers4.js
package/test/tests/registerdynamic-main.js
package/test/tests/all-layers3.js
package/test/tests/plugin-dep.js
package/test/tests/all-layers2.js
package/test/tests/register-regex.js
package/test/tests/all-layers1.js
package/test/tests/reflection.js
package/test/tests/all-circular4.js
package/test/tests/register-circular1.js
package/test/tests/all-circular3.js
package/test/tests/register-circular2.js
package/test/tests/all-circular2.js
package/test/tests/register-default-extension.js
package/test/tests/all-circular1.js
package/test/tests/register-regex-2.js
package/test/tests/default3.js
package/test/tests/zero@0.js
package/test/tests/es6-circular2.js
package/test/tests/plugin@1.2.3/plugin.js
package/test/tests/package-local-alias/index-cjs.js
package/test/tests/package-local-alias/index-default-cjs.js
package/test/tests/package-local-alias/index-default-esm.js
package/test/tests/package-local-alias/index-esm.js
package/test/tests/package-local-alias/local/index-cjs.js
package/test/tests/package-local-alias/local/index-default-cjs.js
package/test/tests/package-local-alias/local/index-default-esm.js
package/test/tests/package-local-alias/local/index-esm.js
package/test/tests/no-default-ext/file.ext
package/test/tests/mypackage/index.js
package/test/tests/mypackage/lib/bar.js
package/test/tests/mypackage/src/foo.js
package/test/tests/shared-dep-bundles/a.js
package/test/tests/shared-dep-bundles/b.js
package/test/tests/map-test/sub.js
package/test/tests/shim-package/shim-map-test.js
package/test/tests/some-json.json
package/test/tests/some-text.txt
package/test/tests/hbs.hbs
package/test/tests/subcontextual-map/submodule.js
package/test/tests/ep/some-repo/main.js
package/test/tests/test.css
package/test/tests/testpkg/depcache-test.js
package/test/tests/testpkg/self.js
package/test/tests/testpkg/env-module-browser.js
package/test/tests/testpkg/env-module.js
package/test/tests/testpkg/index.js
package/test/tests/testpkg/interpolate.js
package/test/tests/testpkg/self-load.js
package/test/tests/testpkg/polate.js
package/test/tests/testpkg/json.js
package/test/tests/testpkg/json.json
package/test/tests/testpkg/dir/index.js
package/test/tests/testpkg/dir/self-load.js
package/test/tests/testpkg/dir2/index.json
package/test/tests/testpkg/system.json
package/test/tests/testpkg/test.ts
package/test/tests/path/deep.js
package/test/tests/testpkg2.json
package/test/tests/typescript.ts
package/test/tests/duplicateDeps/m1.js
package/test/tests/duplicateDeps/m2.js
package/test/tests/deep/deep-dep.js
package/test/tests/deep/deep.js
package/test/tests/css.css
package/test/tests/wildcard-test/2.js
package/test/tests/wildcard-test/first.js
package/test/tests/wildcard-test/2/sub.js
package/test/tests/csp/integrity.js
package/test/tests/csp/nonce.js
package/test/tests/csp/nonce2.js
package/test/tests/cs/dep.js
package/test/tests/cs/main.js
package/test/tests/contextual-test/contextual-map.js
package/test/tests/connected-tree/a.js
package/test/tests/connected-tree/b.js
package/test/tests/connected-tree/c.js
package/test/tests/compiler-test.coffee
package/test/tests/compiled.coffee
package/test/tests/bootstrap@3.1.1/test.coffee
package/test/tests/testpkg2/asdf.asdf.js
-rw-r--r-- 1 munter munter 290085 Apr 14 12:41 systemjs-0.19.26.tgz
```

After:
```
systemjs-0.19.26.tgz
package/package.json
package/README.md
package/LICENSE
package/index.js
package/dist/system-csp-production.js
package/dist/system-csp-production.src.js
package/dist/system-polyfills.js
package/dist/system.js
package/dist/system-polyfills.src.js
package/dist/system-register-only.src.js
package/dist/system.src.js
package/dist/system-register-only.js
package/dist/system-register-only.js.map
package/dist/system-csp-production.js.map
package/dist/system-polyfills.js.map
package/dist/system.js.map
-rw-r--r-- 1 munter munter 223222 Apr 14 12:43 systemjs-0.19.26.tgz
```