### PR TITLE
Fixed wrongly named parameter... seems to be copy paste error from "import".

### DIFF
--- a/lib/conditionals.js
+++ b/lib/conditionals.js
@@ -148,11 +148,11 @@
 
   // normalizeSync does not parse conditionals at all although it could
   hook('normalize', function(normalize) {
-    return function(name, parentName, parentAddress) {
+    return function(name, parentName, skipExt) {
       var loader = this;
       return booleanConditional.call(loader, name, parentName)
       .then(function(name) {
-        return normalize.call(loader, name, parentName, parentAddress);
+        return normalize.call(loader, name, parentName, skipExt);
       })
       .then(function(normalized) {
         return interpolateConditional.call(loader, normalized, parentName);


### PR DESCRIPTION
I think there is a copy paste error in naming. 

I wish there would be a SystemJS without all this „hook“ magic. Makes code pretty hard to understand.