### PR TITLE
Remove falsy dependency values

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -95,6 +95,11 @@ function createEntry() {
       deps = name;
       name = null;
     }
+    
+    // filter `null` dependencies
+    deps = deps.filter(function(module) {
+      return !!module;
+    });
 
     // dynamic backwards-compatibility
     // can be deprecated eventually

--- a/lib/register.js
+++ b/lib/register.js
@@ -95,10 +95,10 @@ function createEntry() {
       deps = name;
       name = null;
     }
-    
+
     // filter `null` dependencies
-    deps = deps.filter(function(module) {
-      return !!module;
+    deps = deps.filter(function(dep) {
+      return !!dep;
     });
 
     // dynamic backwards-compatibility


### PR DESCRIPTION
SystemJS fails to load this module:

```js
System.register("MyFancyModule", [null], function(exports_1, context_1) {
  ...
});
```

> system.js:4 Uncaught (in promise) Error: (SystemJS) Cannot read property 'lastIndexOf' of null

But it can handle:

```js
System.register("MyFancyModule", [], function(exports_1, context_1) {
  ...
});
```

So there is obviously a bug when a dependency has a `null` value. 

With this PR the issue above is fixed but I need guidance on how to write a test for it. :construction_worker: