### PR TITLE
Check for document.currentScript before assigning it

### DIFF
--- a/lib/wrapper-end.js
+++ b/lib/wrapper-end.js
@@ -7,7 +7,7 @@ var doPolyfill = typeof Promise === 'undefined';
 if (typeof document !== 'undefined') {
   var scripts = document.getElementsByTagName('script');
   $__curScript = scripts[scripts.length - 1];
-  if ($__curScript.defer || $__curScript.async)
+  if (document.currentScript && ($__curScript.defer || $__curScript.async))
     $__curScript = document.currentScript;
   if (doPolyfill) {
     var curPath = $__curScript.src;


### PR DESCRIPTION
IE>10 supports [HTMLScriptElement.async](https://developer.mozilla.org/de/docs/Web/API/HTMLScriptElement#Browser_compatibility) but not [document.currentScript](https://developer.mozilla.org/de/docs/Web/API/document/currentScript#Browser_compatibility).