### PR TITLE
allow overriding of fetch function

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -29,7 +29,13 @@ function fetchFetch (url, authorization, integrity, asBuffer) {
     opts.credentials = 'include';
   }
 
-  return fetch(url, opts)
+  var fetch_func;
+  if (typeof self !== 'undefined' && typeof self.systemjs_fetch !== 'undefined') {
+    fetch_func = self.systemjs_fetch;
+  } else {
+    fetch_func = fetch;
+  }
+  return fetch_func(url, opts)
   .then(function(res) {
     if (res.ok)
       return asBuffer ? res.arrayBuffer() : res.text();


### PR DESCRIPTION
Based on https://github.com/systemjs/systemjs/issues/1543 it appears to no longer be possible to override just the fetch functionality (in my case, I needed it to be able to load modules stored in indexeddb, in the context of chrome extensions), without having to reimplement much of SystemJS.constructor.instantiate - this pull request provides a very simple way to override fetch (by setting systemjs_fetch).

I am making this pull request simply because I don't want to have to maintain my own fork of SystemJS in order to be able to override the fetching logic - feel free to suggest changes to the approach.
