### PR TITLE
Use nextjs:main field

### DIFF
--- a/src/instantiate.js
+++ b/src/instantiate.js
@@ -285,7 +285,12 @@ function translateAndInstantiate (loader, key, source, metadata, processAnonRegi
 
       case 'json':
         // warn.call(config, '"json" module format is deprecated.');
-        var parsed = JSON.parse(source);
+        var parsed = JSON.parse(source);  
+        if (!!SystemJS.getConfig().transpiler) {
+            if (parsed['jsnext:main']) {
+                parsed.main = parsed['jsnext:main'];
+            }
+        }
         return loader.newModule({ default: parsed, __useDefault: parsed });
 
       case 'amd':


### PR DESCRIPTION
Hi !

This pull request is a way that i found to come across an issue, i am not sure it's a good way, i putted it there to start discussion

Here is the issue:
I have a Typescript project that use the d3.js library, i installed via npm.
d3 exposes a live binding via the d3.event. Sadly this binding is not live in my application, but is working fine thru the different d3 submodules (the binding is live in the code of the d3 submodules) . I think it makes sense as they are in the same module layer, but not in the same module layer as the modules of my applications (d3 are seen as UMD modules, my app modules are ES modules )

By forcing SystemJS to load d3 modules as ES modules, everything works fine, and the binding is live ( as my application is made of ES modules). I made a change to the code to force SystemJS to use the nextjs:main field if a transpiler is used; i am not sure if it's the good way, but i think it makes sense; if a module comes with a ES module, then we should use it ?. Or is there a better way to do it ?

Thanks a lot !

Here is some discussion around that issue: 
https://github.com/systemjs/systemjs/issues/1687