### PR TITLE
Fix the context scope of SystemJS.register when called from browsers System.register

### DIFF
--- a/src/system-production.js
+++ b/src/system-production.js
@@ -19,7 +19,7 @@ if (isBrowser || isWorker) {
     global.System.register = function () {
       if (register)
         register.apply(this, arguments);
-      System.register.apply(this, arguments);
+      System.register.apply(System, arguments);
     };
   }
 }


### PR DESCRIPTION
The SystemJS.register requires the correct `this`. If modules are registered using `System.register` (as opposed to `SystemJS.register`) AND there exists another `global.System` object, the register module call fails, in my case the error was: 

```
register-loader.js:456 Uncaught TypeError: Cannot set property 'lastRegister' of undefined
    at Object.RegisterLoader$1.register (register-loader.js:456)
    at Object.systemJSPrototype.register (systemjs-production-loader.js:206)
    at Object.envGlobal.System.register (system-production.js:22)
    at main.js:1
```