### PR TITLE
Fix broken in-page link to pluginFirst section

### DIFF
--- a/docs/config-api.md
+++ b/docs/config-api.md
@@ -9,7 +9,7 @@
 * [meta](#meta)
 * [packages](#packages)
 * [packageConfigPaths](#packageconfigpaths)
-* [pluginFirst](#pluginFirst)
+* [pluginFirst](#pluginfirst)
 * [paths](#paths)
 * [transpiler](#transpiler)
 * [warnings](#warnings)


### PR DESCRIPTION
quick fix to match the casing of pluginFirst link to the heading