### PR TITLE
fix for issue #1658 when no package meta is present.

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -571,7 +571,7 @@ function doMapSync (loader, config, pkg, pkgKey, mapMatch, path, metadata, skipE
   if (!validMapping(mapMatch, mapped, path) || typeof mapped !== 'string')
     return;
 
-  return packageResolveSync.call(this, config, mapped + path.substr(mapMatch.length), pkgKey + '/', metadata, metadata, skipExtensions);
+  return packageResolveSync.call(loader, config, mapped + path.substr(mapMatch.length), pkgKey + '/', metadata, metadata, skipExtensions);
 }
 
 function applyPackageConfig (loader, config, pkg, pkgKey, subPath, metadata, skipExtensions) {


### PR DESCRIPTION
As [mentioned in issue 1658](https://github.com/systemjs/systemjs/issues/1658#issuecomment-320234623), this is an extra fix earlier in the process of package resolving, in the case of plugin-hbs for resolving a child package within a parent.