### PR TITLE
fix plugin without translate still transpiling

### DIFF
--- a/src/instantiate.js
+++ b/src/instantiate.js
@@ -204,10 +204,14 @@ function translateAndInstantiate (loader, key, source, metadata, processAnonRegi
 
     readMetaSyntax(source, metadata);
 
-    if (!metadata.pluginModule || !metadata.pluginModule.translate)
+    if (!metadata.pluginModule)
       return source;
 
     metadata.pluginLoad.source = source;
+
+    if (!metadata.pluginModule.translate)
+      return source;
+
     return Promise.resolve(metadata.pluginModule.translate.call(loader, metadata.pluginLoad, metadata.traceOpts))
     .then(function (translated) {
       if (metadata.load.sourceMap) {


### PR DESCRIPTION
I dove into SystemJS plugin writing and instantly found I could not get a module transpiled if I did not implement the 'translate' method.

## Example

script.js:

```javascript
#!/usr/bin/env node

const SystemJS = require('systemjs')

SystemJS.config({
  map: {
    'plugin-babel': 'node_modules/systemjs-plugin-babel/plugin-babel.js',
    'systemjs-babel-build': 'node_modules/systemjs-plugin-babel/systemjs-babel-node.js'
  },
  meta: {
    'builtin/*': {
      loader: 'builtin-loader.js',
    }
  },
  transpiler: 'plugin-babel',
})

const main = async () => {
  const realmod = await SystemJS.import('./real-module.js')
  console.log('=> real-module:', realmod)

  const builtinmod = await SystemJS.import('builtin/helloworld')
  console.log('=> builtin:', builtinmod)
}

main()
```

real-module.js:

```javascript
const x = () => "hi" ; export {x as default}
```

builtin-loader.js:

```javascript
export const fetch = async (a, b) => {
  return Promise.resolve().then(() => {
    return 'const x = () => "hi" ; export {x as default}\n'
  })
}
```

## Results

Running `script.js` produced this:

```
$ ./script.js
=> real-module: { default: [Getter] }
=> builtin: {}
```

I see an empty module returned.

After coming up with this patch (tests passing: `yarn && yarn build && yarn test`), I get the expected result:

```
$ ./script.js
=> real-module: { default: [Getter] }
=> builtin: { default: [Getter] }
```

Now I see the same module returned as expected.