### PR TITLE
Support backticks (`) in cjs require module detection

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -293,4 +293,4 @@ export function getMapMatch (map, name) {
 }
 
 // RegEx adjusted from https://github.com/jbrantly/yabble/blob/master/lib/yabble.js#L339
-export var cjsRequireRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF."'])require\s*\(\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')\s*\)/g;
+export var cjsRequireRegEx = /(?:^\uFEFF?|[^$_a-zA-Z\xA0-\uFFFF."'])require\s*\(\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|`[^'\\]*(?:\\.[^'\\]*)*`)\s*\)/g


### PR DESCRIPTION
using a module with require(\`foo\`) fails to be detected as a common js module.