### PR TITLE
Enable nodeFetch to fallback to fetchFetch

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -93,9 +93,13 @@ function xhrFetch (url, authorization, integrity, asBuffer) {
 
 var fs;
 function nodeFetch (url, authorization, integrity, asBuffer) {
-  if (url.substr(0, 8) != 'file:///')
-    return Promise.reject(new Error('Unable to fetch "' + url + '". Only file URLs of the form file:/// supported running in Node.'));
-
+  if (url.substr(0, 8) != 'file:///') {
+    if (hasFetch)
+      return fetchFetch(url, authorization, integrity, asBuffer);
+    else
+      return Promise.reject(new Error('Unable to fetch "' + url + '". Only file URLs of the form file:/// supported running in Node without fetch.'));
+  }
+  
   fs = fs || require('fs');
   if (isWindows)
     url = url.replace(/\//g, '\\').substr(8);
@@ -131,6 +135,7 @@ function noFetch () {
 var fetchFunction;
 
 var hasXhr = typeof XMLHttpRequest !== 'undefined';
+var hasFetch = typeof fetch !== 'undefined';
 
 if (typeof self !== 'undefined' && typeof self.fetch !== 'undefined')
  fetchFunction = fetchFetch;


### PR DESCRIPTION
This allows http(s) requests from NodeJS.

```javascript
// set global fetch (not the same as self.fetch)
global.fetch = require('node-fetch');

// this will use nodeFetch by default
const SystemJS = require('systemjs');

// nodeFetch will fail regex on `file://` prefix and fallback to fetchFetch logic
SystemJS.import('https://unpkg.com/react@16.0.0/umd/react.production.min.js').then(react => {
  console.log('react', react);
});
```

related topic: https://github.com/systemjs/systemjs/issues/1543