### PR TITLE
Present credentials for same origin fetch requests

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -17,6 +17,7 @@ function fetchFetch (url, authorization, integrity, asBuffer) {
 
   var opts = {
     // NB deprecate
+    credentials: "same-origin",
     headers: { Accept: 'application/x-es-module, */*' }
   };
 


### PR DESCRIPTION
Example use case: Deploy pydio (which depends on systemjs) to an environment which requires presenting PKI certs for all HTTP traffic, including JS fetch requests.

At present with the current version of systemjs, that use case is broken in Firefox and Safari. Applying this fix allows the JS fetch to present credentials to the server and thus allows the fetch to proceed.