### PR TITLE
fix for #1888 prevent scriptLoad on plugin loads

### DIFF
--- a/src/instantiate.js
+++ b/src/instantiate.js
@@ -42,12 +42,12 @@ export function instantiate (key, processAnonRegister) {
     }
 
     if (metadata.load.scriptLoad ) {
-      if (metadata.load.pluginKey || !supportsScriptLoad) {
+      if (metadata.pluginKey || !supportsScriptLoad) {
         metadata.load.scriptLoad = false;
         warn.call(config, 'scriptLoad not supported for "' + key + '"');
       }
     }
-    else if (metadata.load.scriptLoad !== false && !metadata.load.pluginKey && supportsScriptLoad) {
+    else if (metadata.load.scriptLoad !== false && !metadata.pluginKey && supportsScriptLoad) {
       // auto script load AMD, global without deps
       if (!metadata.load.deps && !metadata.load.globals &&
           (metadata.load.format === 'system' || metadata.load.format === 'register' || metadata.load.format === 'global' && metadata.load.exports))

--- a/test/test.js
+++ b/test/test.js
@@ -789,6 +789,41 @@ suite('SystemJS Standard Tests', function() {
     });
   });
 
+  if (typeof process === 'undefined') {
+    test('Disallow scriptLoad with plugin', function () {
+      System.config({
+        meta: {
+          "*.js": {
+            scriptLoad: true,
+            format: "register"
+          },
+          "tests/text-plugin.js": {
+            scriptLoad: false,
+            format: "cjs"
+          }
+        }
+      });
+      return System.import('tests/script-load-test.js!tests/text-plugin.js').then(function (m) {
+        ok(m.startsWith("define"));
+      }).finally(function () {
+
+        //Cleanup after tests
+        System.config({
+          meta: {
+            "*.js": {
+              scriptLoad: undefined,
+              format: undefined
+            },
+            "tests/text-plugin.js": {
+              scriptLoad: undefined,
+              format: undefined
+            }
+          }
+        });
+      });
+    })
+  }
+
   test('AMD Circular', function () {
     return System.import('tests/amd-circular1.js').then(function (m) {
       ok(m.outFunc() == 5, 'Expected execution');

--- a/test/tests/script-load-test.js
+++ b/test/tests/script-load-test.js
@@ -1,0 +1,3 @@
+define(function () {
+	return "Hello World";
+});


### PR DESCRIPTION
I was finally able to repro using tests. Since `scriptLoad` is not supported under node, the regression test only works inside browsers.