### PR TITLE
Support System.has and System.set

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -39,10 +39,10 @@ Resolves a module specifier relative to an optional parent URL, returning the re
 
 ### Registry API (system.js only)
 
-#### System.delete(url) -> Boolean
+#### System.delete(id) -> Boolean
 Type: `Function`
 
-Deletes a module from the registry by URL.
+Deletes a module from the registry by ID.
 
 Returns true if the module was found in the registry before deletion.
 
@@ -50,11 +50,40 @@ Returns true if the module was found in the registry before deletion.
 System.delete('http://site.com/normalized/module/name.js');
 ```
 
-#### System.get(url) -> Module
+#### System.get(id) -> Module
 Type: `Function`
 
-Retrieve a loaded module from the registry by URL.
+Retrieve a loaded module from the registry by ID.
 
 ```js
 System.get('http://site.com/normalized/module/name.js').exportedFunction();
 ```
+
+Module records with an error state will return `null`.
+
+#### System.has(id) -> Boolean
+Type: `Function`
+
+Determine if a given ID is available in the loader registry.
+
+Module records that have an error state in the registry still return `true`,
+while module records with in-progress loads will return `false`.
+
+```js
+System.get('http://site.com/normalized/module/name.js').exportedFunction();
+```
+
+#### System.set(id, module) -> Module
+Type: `Function`
+
+Sets a module in the registry by ID.
+
+```js
+System.set('http://site.com/normalized/module/name.js', {
+  exportedFunction: value
+});
+```
+
+`module` is an object of names to set as the named exports.
+
+If `module` is an existing Module Namespace, it will be used by reference.

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -1,5 +1,7 @@
 import { systemJSPrototype, REGISTRY } from '../system-core.js';
 
+const toStringTag = typeof Symbol !== 'undefined' && Symbol.toStringTag;
+
 systemJSPrototype.get = function (id) {
   const load = this[REGISTRY][id];
   if (load && load.e === null && !load.E) {
@@ -7,6 +9,38 @@ systemJSPrototype.get = function (id) {
       return null;
     return load.n;
   }
+};
+
+systemJSPrototype.set = function (id, module) {
+  let ns;
+  if (toStringTag && module[toStringTag] === 'Module') {
+    ns = module;
+  }
+  else {
+    ns = Object.assign(Object.create(null), module);
+    if (toStringTag)
+      Object.defineProperty(ns, toStringTag, { value: 'Module' });
+  }
+  const done = Promise.resolve(ns);
+  this.delete(id);
+  this[REGISTRY][id] = {
+    id: id,
+    i: [],
+    n: ns,
+    I: done,
+    L: done,
+    h: false,
+    d: [],
+    e: null,
+    eE: undefined,
+    E: undefined,
+    C: done
+  };
+};
+
+systemJSPrototype.has = function (id) {
+  const load = this[REGISTRY][id];
+  return load && load.e === null && !load.E;
 };
 
 // Delete function provided for hot-reloading use cases

--- a/test/system-core.js
+++ b/test/system-core.js
@@ -110,9 +110,19 @@ describe('Core API', function () {
       assert.equal(loader.get('x').y, 42);
     });
 
+    it('Supports System.has', function () {
+      assert.equal(loader.has('x'), true);
+    });
+
     it('Supports System.delete', function () {
       loader.delete('x');
       assert.equal(loader.get('x'), undefined);
+    });
+
+    it('Supports System.set', async function () {
+      loader.set('x', { y: 43 });
+      const x = await loader.import('x');
+      assert.equal(x.y, 43);
     });
   });
 });


### PR DESCRIPTION
This adds support for `System.has` and `System.set` for the SystemJS API (not the s.js API).

May help provide a path for use cases like #1869.