### PR TITLE
Add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Guy Bedford",
   "mode": "esm",
   "license": "MIT",
+  "main": "dist/s.min.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
CI Build validation checks fail when importing a node_module without a `main` field in the `package.json`
To ensure the pattern is consistent with [SystemJS v1](https://github.com/systemjs/systemjs/blob/1.0/package.json#L14), adding the main field back.

Please let me know if this should be pointing to a different file.