### PR TITLE
Remove unneeded parentheses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -97,5 +97,5 @@ Allows you to retrieve all modules in the System registry. Each value will be an
 for (const [id, ns] of System.entries()) {
   console.log(id); // 'http://localhost/path-to-file.js'
   console.log(ns); // { exportName: 'value' }
-});
+};
 ```


### PR DESCRIPTION
Removed unneeded parentheses from ```System.entries``` example, in order to work as expected.