### PR TITLE
Fixing IE11 compatibility for System.entries(). Resolves #1935.

### DIFF
--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -65,7 +65,7 @@ const iterator = typeof Symbol !== 'undefined' && Symbol.iterator;
 systemJSPrototype.entries = function () {
   const loader = this, keys = Object.keys(loader[REGISTRY]);
   let index = 0, ns, key;
-  return {
+  const result = {
     next: function () {
       while (
         (key = keys[index++]) !== undefined && 
@@ -75,7 +75,12 @@ systemJSPrototype.entries = function () {
         done: key === undefined,
         value: key !== undefined && [key, ns]
       };
-    },
-    [iterator]: function() { return this }
+    }
   };
+
+  if (iterator) {
+    result[iterator] = function() { return this };
+  }
+
+  return result;
 };

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -78,9 +78,7 @@ systemJSPrototype.entries = function () {
     }
   };
 
-  if (iterator) {
-    result[iterator] = function() { return this };
-  }
+  result[iterator] = function() { return this };
 
   return result;
 };


### PR DESCRIPTION
Computed object properties are not supported in IE11. See #1935 