### PR TITLE
Support amd importing esm through __useDefault pattern

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -39,7 +39,7 @@
         // needed for ie11 lack of iteration scope
         const idx = i;
         setters.push(function (ns) {
-          depModules[idx] = ns.default;
+          depModules[idx] = ns.__useDefault ? ns.default : ns;
         });
       }
       if (splice)
@@ -49,7 +49,7 @@
       amdDefineDeps.length -= splice;
     const amdExec = amdDefineExec;
     return [amdDefineDeps, function (_export) {
-      _export('default', exports);
+      _export({ default: exports, __useDefault: true });
       return {
         setters: setters,
         execute: function () {

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -71,7 +71,11 @@ systemJSPrototype.getRegister = function () {
   }
 
   return [[], function (_export) {
-    return { execute: function () { _export('default', globalExport) } };
+    return {
+      execute: function () {
+        _export({ default: globalExport, __useDefault: true });
+      }
+    };
   }];
 };
 

--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -29,6 +29,8 @@
       const declaration = registerDeclare.call(this, function (name, value) {
         if (name === 'default')
           defaultExport = value;
+        if (name === '__useDefault')
+          return;
         _export(name, value);
       }, _context);
       // hook the execute function

--- a/test/browser/amd.js
+++ b/test/browser/amd.js
@@ -21,6 +21,14 @@ suite('AMD tests', function () {
     });
   });
 
+  test('Loading an AMD module with ES module dep', function () {
+    return System.import('fixtures/amd-module-esm-dep.js').then(function (m) {
+      assert.ok(m.default);
+      assert.equal(m.default.esm, 'export');
+      assert.equal('default' in m.default, false);
+    });
+  });
+
   test('Loading AMD exports dependency', function () {
     return System.import('fixtures/amd-exports.js').then(function (m) {
       assert.ok(m.default);

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -11,7 +11,7 @@ suite('Named System.register', function() {
 
   test('Loading a named AMD bundle', function () {
     return System.import('./fixtures/browser/named-amd.js').then(function (m) {
-      assert.equal(Object.keys(m).length, 1);
+      assert.equal(Object.keys(m).length, 2);
       return System.import('c');
     })
     .then(function (m) {

--- a/test/fixtures/browser/amd-module-esm-dep.js
+++ b/test/fixtures/browser/amd-module-esm-dep.js
@@ -1,0 +1,3 @@
+define(['./esm.js'], function (esm) {
+  return esm;
+});

--- a/test/fixtures/browser/esm.js
+++ b/test/fixtures/browser/esm.js
@@ -1,0 +1,8 @@
+System.register([], function (_export) {
+  return {
+    setters: [],
+    execute: function () {
+      _export({ esm: 'export' });
+    }
+  };
+});


### PR DESCRIPTION
This resolves https://github.com/systemjs/systemjs/issues/1933 while ensuring that we don't break the standard interop patterns.