### PR TITLE
Implementing loading JSON modules. Resolves #1949.

### DIFF
--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -18,26 +18,36 @@ systemJSPrototype.register = function (deps, declare) {
 
 systemJSPrototype.instantiate = function (url, firstParentUrl) {
   const loader = this;
-  return new Promise(function (resolve, reject) {
-    const script = document.createElement('script');
-    script.charset = 'utf-8';
-    script.async = true;
-    script.crossOrigin = 'anonymous';
-    script.addEventListener('error', function () {
-      reject(new Error('Error loading ' + url + (firstParentUrl ? ' from ' + firstParentUrl : '')));
+  if (url.endsWith('.json')) {
+    return fetch(url).then(function (resp) {
+      return resp.json()
+    }).then(function (json) {
+      return [[], function(_export) {
+        return {execute: function() {_export('default', json)}}
+      }];
+    })
+  } else {
+    return new Promise(function (resolve, reject) {
+      const script = document.createElement('script');
+      script.charset = 'utf-8';
+      script.async = true;
+      script.crossOrigin = 'anonymous';
+      script.addEventListener('error', function () {
+        reject(new Error('Error loading ' + url + (firstParentUrl ? ' from ' + firstParentUrl : '')));
+      });
+      script.addEventListener('load', function () {
+        document.head.removeChild(script);
+        // Note URL normalization issues are going to be a careful concern here
+        if (err) {
+          reject(err);
+          return err = undefined;
+        }
+        else {
+          resolve(loader.getRegister());
+        }
+      });
+      script.src = url;
+      document.head.appendChild(script);
     });
-    script.addEventListener('load', function () {
-      document.head.removeChild(script);
-      // Note URL normalization issues are going to be a careful concern here
-      if (err) {
-        reject(err);
-        return err = undefined;
-      }
-      else {
-        resolve(loader.getRegister());
-      }
-    });
-    script.src = url;
-    document.head.appendChild(script);
-  });
+  }
 };

--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -20,12 +20,12 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
   const loader = this;
   if (url.endsWith('.json')) {
     return fetch(url).then(function (resp) {
-      return resp.json()
+      return resp.json();
     }).then(function (json) {
       return [[], function(_export) {
-        return {execute: function() {_export('default', json)}}
+        return {execute: function() {_export('default', json)}};
       }];
-    })
+    });
   } else {
     return new Promise(function (resolve, reject) {
       const script = document.createElement('script');


### PR DESCRIPTION
Resolves #1949 

Checking `url.endsWith('.json')` is incomplete and not spec compliant. But it's an easy implementation that does not require first trying `<script>` tag and then trying XHR + `JSON.parse()` if the script fails.

Open to any feedback on that decision.