### PR TITLE
Switching from new Error() -> Error() to save bytes.

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -26,7 +26,7 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
     const parentProtocol = parentUrl.slice(0, parentUrl.indexOf(':') + 1);
     // Disabled, but these cases will give inconsistent results for deep backtracking
     //if (parentUrl[parentProtocol.length] !== '/')
-    //  throw new Error('Cannot resolve');
+    //  throw Error('Cannot resolve');
     // read pathname from parent URL
     // pathname taken to be part after leading "/"
     let pathname;
@@ -172,5 +172,5 @@ export function resolveImportMap (id, parentUrl, importMap) {
 }
 
 export function throwBare (id, parentUrl) {
-  throw new Error('Unable to resolve bare specifier "' + id + (parentUrl ? '" from ' + parentUrl : '"'));
+  throw Error('Unable to resolve bare specifier "' + id + (parentUrl ? '" from ' + parentUrl : '"'));
 }

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -7,7 +7,7 @@
   const emptyInstantiation = [[], function () { return {} }];
 
   function unsupportedRequire () {
-    throw new Error('AMD require not supported.');
+    throw Error('AMD require not supported.');
   }
 
   function emptyFn () {}
@@ -101,7 +101,7 @@
     if (typeof name === 'string') {
       if (amdDefineDeps) {
         if (!System.registerRegistry)
-          throw new Error('Include the named register extension for SystemJS named AMD support.');
+          throw Error('Include the named register extension for SystemJS named AMD support.');
         System.registerRegistry[name] = createAMDRegister(deps, execute);
         amdDefineDeps = [];
         amdDefineExec = emptyFn;

--- a/src/extras/transform.js
+++ b/src/extras/transform.js
@@ -13,7 +13,7 @@
     return fetch(url, { credentials: 'same-origin' })
     .then(function (res) {
       if (!res.ok)
-        throw new Error('Fetch error: ' + res.status + ' ' + res.statusText + (parent ? ' loading from ' + parent : ''));
+        throw Error('Fetch error: ' + res.status + ' ' + res.statusText + (parent ? ' loading from ' + parent : ''));
       return res.text();
     })
     .then(function (source) {

--- a/src/features/basic-resolve.js
+++ b/src/features/basic-resolve.js
@@ -5,7 +5,7 @@ systemJSPrototype.resolve = function (id, parentUrl) {
   if (!resolved) {
     if (id.indexOf(':') !== -1)
       return Promise.resolve(id);
-    throw new Error('Cannot resolve "' + id + (parentUrl ? '" from ' + parentUrl : '"'));
+    throw Error('Cannot resolve "' + id + (parentUrl ? '" from ' + parentUrl : '"'));
   }
   return Promise.resolve(resolved);
 };

--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -24,7 +24,7 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
     script.async = true;
     script.crossOrigin = 'anonymous';
     script.addEventListener('error', function () {
-      reject(new Error('Error loading ' + url + (firstParentUrl ? ' from ' + firstParentUrl : '')));
+      reject(Error('Error loading ' + url + (firstParentUrl ? ' from ' + firstParentUrl : '')));
     });
     script.addEventListener('load', function () {
       document.head.removeChild(script);

--- a/src/features/wasm-load.js
+++ b/src/features/wasm-load.js
@@ -11,7 +11,7 @@ systemJSPrototype.instantiate = function (url, parent) {
   return fetch(url)
   .then(function (res) {
     if (!res.ok)
-      throw new Error(res.status + ' ' + res.statusText + ' ' + res.url + (parent ? ' loading from ' + parent : ''));
+      throw Error(res.status + ' ' + res.statusText + ' ' + res.url + (parent ? ' loading from ' + parent : ''));
 
     if (WebAssembly.compileStreaming)
       return WebAssembly.compileStreaming(res);

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -76,7 +76,7 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
   })
   .then(function (registration) {
     if (!registration)
-      throw new Error('Module ' + id + ' did not instantiate');
+      throw Error('Module ' + id + ' did not instantiate');
     function _export (name, value) {
       // note if we have hoisted exports (including reexports)
       load.h = true;


### PR DESCRIPTION
You can call `Error()` without using `new` and it behaves exactly the same as if you had done `new Error()`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Used_as_a_function. I have done this for a year or two now, including when supporting IE11. So I think this should work in all of systemjs' browsers.

Switching from `new Error()` to `Error()` saves 32 bytes in the dist files, between system.min.js and all of the extras.