### PR TITLE
Fix for System.import() rejecting for other script's errors. Resolves #1960

### DIFF
--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -4,10 +4,10 @@
 
 import { systemJSPrototype } from '../system-core';
 
-let err;
+let errEvt;
 if (typeof window !== 'undefined')
   window.addEventListener('error', function (e) {
-    err = e.error;
+    errEvt = e;
   });
 
 const systemRegister = systemJSPrototype.register;
@@ -37,10 +37,11 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
       });
       script.addEventListener('load', function () {
         document.head.removeChild(script);
-        // Note URL normalization issues are going to be a careful concern here
-        if (err) {
-          reject(err);
-          return err = undefined;
+        // Note that if an error occurs that isn't caught by this if statement,
+        // that getRegister will return null and a "did not instantiate" error will be thrown.
+        if (errEvt && errEvt.filename === url) {
+          reject(errEvt.error);
+          errEvt = undefined;
         }
         else {
           resolve(loader.getRegister());


### PR DESCRIPTION
See #1960. Also see https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent#Browser_compatibility. The `errEvt.filename` property is supported in all evergreen browsers, but IE11 support is unknown.

The fix is to only reject the System.import() promise if the error reported to the window event listener originated from the script at the URL for the one specific module that is being imported.