### PR TITLE
Fix ReferenceError. Resolves #1965.

### DIFF
--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -6,7 +6,6 @@ import { systemJSPrototype } from '../system-core';
 
 const systemRegister = systemJSPrototype.register;
 systemJSPrototype.register = function (deps, declare) {
-  err = undefined;
   systemRegister.call(this, deps, declare);
 };
 


### PR DESCRIPTION
See #1965. I believe that the error described in the issue only occurs in strict mode, which is what explains why it wasn't caught by our testing.