### PR TITLE
fix(extras): avoid to check frames in global import

### DIFF
--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -13,7 +13,8 @@ function getGlobalProp () {
   let cnt = 0;
   let lastProp;
   for (let p in global) {
-    if (!global.hasOwnProperty(p))
+    // do not check frames cause it could be removed during import
+    if (!global.hasOwnProperty(p) || (!isNaN(p) && p < global.frames.length))
       continue;
     if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
       return p;
@@ -29,7 +30,8 @@ function noteGlobalProps () {
   // but this may be faster (pending benchmarks)
   firstGlobalProp = secondGlobalProp = undefined;
   for (let p in global) {
-    if (!global.hasOwnProperty(p))
+    // do not check frames cause it could be removed during import
+    if (!global.hasOwnProperty(p) || (!isNaN(p) && p < global.frames.length))
       continue;
     if (!firstGlobalProp)
       firstGlobalProp = p;

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -14,7 +14,7 @@ function getGlobalProp () {
   let lastProp;
   for (let p in global) {
     // do not check frames cause it could be removed during import
-    if (!global.hasOwnProperty(p) || (!isNaN(p) && p < global.frames.length))
+    if (!global.hasOwnProperty(p) || (!isNaN(p) && p < global.length))
       continue;
     if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
       return p;


### PR DESCRIPTION
Avoid to check frames when comparing properties

**eg:** routing from a page with iframe to a new page which import global.
Then, the iframe is unmounted during import and "global" value is not the same between noteGlobalProps and getGlobalProp.