### PR TITLE
Resolve scopes relative to import map base

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -134,7 +134,7 @@ export function parseImportMap (json, baseUrl) {
       let resolvedScopeName = resolveUrl(scopeName, baseUrl);
       if (resolvedScopeName[resolvedScopeName.length - 1] !== '/')
         resolvedScopeName += '/';
-      scopes[resolvedScopeName] = resolvePackages(scope, resolvedScopeName) || {};
+      scopes[resolvedScopeName] = resolvePackages(scope, baseUrl) || {};
     }
   }
 

--- a/src/common.js
+++ b/src/common.js
@@ -156,8 +156,7 @@ function applyPackages (id, packages) {
   const pkgName = getMatch(id, packages);
   if (pkgName) {
     const pkg = packages[pkgName];
-    if (pkg === null)
-
+    if (pkg === null) return;
     if (id.length > pkgName.length && pkg[pkg.length - 1] !== '/')
       console.warn("Invalid package target " + pkg + " for '" + pkgName + "' should have a trailing '/'.");
     return pkg + id.slice(pkgName.length);

--- a/test/import-map.js
+++ b/test/import-map.js
@@ -73,7 +73,7 @@ describe('Import Maps', function () {
   });
 
   it('Resolves scoped package subpaths', function () {
-    assert.equal(resolveImportMap('x/sub', 'https://sample.com/scope/y', importMap), 'https://sample.com/scope/y/sub');
+    assert.equal(resolveImportMap('x/sub', 'https://sample.com/scope/y', importMap), 'https://sample.com/src/y/sub');
   });
 
   it('Overrides package resolution when two import maps define the same module', function () {
@@ -105,7 +105,7 @@ describe('Import Maps', function () {
       }
     }, 'https://sample.com/src/');
     const finalMap = mergeImportMap(importMap, secondMap);
-    assert.equal(resolveImportMap('x/file.js', 'https://sample.com/scope/something', finalMap), 'https://sample.com/scope/z/file.js');
+    assert.equal(resolveImportMap('x/file.js', 'https://sample.com/scope/something', finalMap), 'https://sample.com/src/z/file.js');
   });
 
   it('Adds an import map scope when two import maps are merged', function () {


### PR DESCRIPTION
This implements https://github.com/systemjs/systemjs/issues/1968 in resolving scopes relative to the baseUrl, as was implemented in the import maps spec update.

As a major change this will form a SystemJS v5, so it's worth thinking about if we have any other major changes we'd like to add to the mix before merging and releasing here.