### PR TITLE
Fixing named-exports to not alter default export.

### DIFF
--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -46,7 +46,7 @@
             for (let name in defaultExport) {
               // default is not a named export
               if (name !== 'default') {
-                _export(name, defaultExport[name])
+                _export(name, defaultExport[name]);
               }
             }
         };

--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -43,7 +43,12 @@
           // do a bulk export of the default export object
           // to export all its names as named exports
           if (hasDefaultExport && typeof defaultExport === 'object')
-            _export(defaultExport);
+            for (let name in defaultExport) {
+              // default is not a named export
+              if (name !== 'default') {
+                _export(name, defaultExport[name])
+              }
+            }
         };
       return declaration;
     };


### PR DESCRIPTION
See [this codepen](https://codepen.io/joeldenning/project/editor/ABpkMK#) for the weird behavior that this fixes.

The named-exports extra is accidentally changing the default export, if the exported object has a default property on it.