### PR TITLE
Supporting System.import for a single named System.register module

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -64,20 +64,10 @@
   // hook System.register to know the last declaration binding
   let lastRegisterDeclare;
   const systemRegister = systemPrototype.register;
-  // if we have named register support continue to use it
-  if (systemRegister.length === 3) {
-    systemPrototype.register = function (name, deps, declare) {
-      if (typeof name !== 'string')
-        lastRegisterDeclare = deps;
-      systemRegister.apply(this, arguments);
-    };
-  }
-  else {
-    systemPrototype.register = function (deps, declare) {
-      lastRegisterDeclare = declare;
-      systemRegister.apply(this, arguments);
-    };
-  }
+  systemPrototype.register = function (name, deps, declare) {
+    lastRegisterDeclare = typeof name === 'string' ? declare : deps;
+    systemRegister.apply(this, arguments);
+  };
 
   const getRegister = systemPrototype.getRegister;
   systemPrototype.getRegister = function () {

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -49,6 +49,7 @@ systemJSPrototype.import = function (id, parentUrl) {
 };
 
 const emptyInstantiation = [[], function () { return {} }];
+emptyInstantiation.isEmpty = true;
 
 const getRegister = systemJSPrototype.getRegister;
 systemJSPrototype.getRegister = function () {

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -49,7 +49,6 @@ systemJSPrototype.import = function (id, parentUrl) {
 };
 
 const emptyInstantiation = [[], function () { return {} }];
-emptyInstantiation.isEmpty = true;
 
 const getRegister = systemJSPrototype.getRegister;
 systemJSPrototype.getRegister = function () {

--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -7,7 +7,10 @@
   // hook System.register to know the last declaration binding
   let lastRegisterDeclare;
   const systemRegister = systemPrototype.register;
-  systemPrototype.register = function (deps, declare) {
+  systemPrototype.register = function () {
+    const isNamedRegister = arguments.length === 3
+    const deps = isNamedRegister ? arguments[1] : arguments[0];
+    const declare = isNamedRegister ? arguments[2] : arguments[1];
     lastRegisterDeclare = declare;
     systemRegister.call(this, deps, declare);
   };

--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -7,12 +7,9 @@
   // hook System.register to know the last declaration binding
   let lastRegisterDeclare;
   const systemRegister = systemPrototype.register;
-  systemPrototype.register = function () {
-    const isNamedRegister = arguments.length === 3
-    const deps = isNamedRegister ? arguments[1] : arguments[0];
-    const declare = isNamedRegister ? arguments[2] : arguments[1];
-    lastRegisterDeclare = declare;
-    systemRegister.call(this, deps, declare);
+  systemPrototype.register = function (name, deps, declare) {
+    lastRegisterDeclare = typeof name === 'string' ? declare : deps;
+    systemRegister.apply(this, arguments);
   };
 
   const getRegister = systemPrototype.getRegister;

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -16,15 +16,14 @@
   SystemJS.prototype = systemJSPrototype;
   System = new SystemJS();
 
+  let lastNamedDefine;
+
   const register = systemJSPrototype.register;
   systemJSPrototype.register = function (name, deps, declare) {
     if (typeof name !== 'string')
       return register.apply(this, arguments);
 
-    this.registerRegistry[name] = [deps, declare];
-
-    // Provide an empty module to signal success.
-    return register.call(this, [], function () { return {}; });
+    this.registerRegistry[name] = lastNamedDefine = [deps, declare];
   };
 
   const resolve = systemJSPrototype.resolve;
@@ -40,4 +39,14 @@
   systemJSPrototype.instantiate = function (url, firstParentUrl) {
     return this.registerRegistry[url] || instantiate.call(this, url, firstParentUrl);
   };
+
+  const getRegister = systemJSPrototype.getRegister;
+  systemJSPrototype.getRegister = function () {
+    let result = getRegister.apply(this, arguments);
+    if (!result || result.isEmpty) {
+      result = lastNamedDefine;
+    }
+    lastNamedDefine = null;
+    return result;
+  }
 })();

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -18,4 +18,11 @@ suite('Named System.register', function() {
       assert.equal(m.default.a, 'b');
     });
   });
+
+  test('Loading a single named System.register module', function () {
+    return System.import('./fixtures/browser/single-named-module.js').then(function (m) {
+      assert.equal(Object.keys(m).length, 1);
+      assert.equal(m.b, 'c')
+    })
+  });
 });

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -1,11 +1,11 @@
 suite('Named System.register', function() {
   test('Loading a named System.register bundle', function () {
     return System.import('./fixtures/browser/named-bundle.js').then(function (m) {
-      assert.equal(Object.keys(m).length, 0);
-      return System.import('a');
+      assert.equal(m.a, 'b');
+      return System.import('b');
     })
     .then(function (m) {
-      assert.equal(m.a, 'b');
+      assert.equal(m.b, 'b');
     });
   });
 

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -22,7 +22,7 @@ suite('Named System.register', function() {
   test('Loading a single named System.register module', function () {
     return System.import('./fixtures/browser/single-named-module.js').then(function (m) {
       assert.equal(Object.keys(m).length, 1);
-      assert.equal(m.b, 'c')
-    })
+      assert.equal(m.b, 'c');
+    });
   });
 });

--- a/test/fixtures/browser/importmap.json
+++ b/test/fixtures/browser/importmap.json
@@ -15,7 +15,7 @@
       "maptest/": "./contextual-map-dep/"
     },
     "wasm": {
-      "example": "./example.js"
+      "example": "./wasm/example.js"
     }
   }
 }

--- a/test/fixtures/browser/named-bundle.js
+++ b/test/fixtures/browser/named-bundle.js
@@ -1,4 +1,4 @@
-System.register('a', ['./b'], function (exports) {
+System.register('a', ['b'], function (exports) {
   var b;
   return {
     setters: [function (m) {

--- a/test/fixtures/browser/single-named-module.js
+++ b/test/fixtures/browser/single-named-module.js
@@ -1,7 +1,7 @@
 System.register('a', [], function (_export) {
   return {
     execute: function() {
-      _export('b', 'c')
+      _export('b', 'c');
     }
-  }
-})
+  };
+});

--- a/test/fixtures/browser/single-named-module.js
+++ b/test/fixtures/browser/single-named-module.js
@@ -1,0 +1,7 @@
+System.register('a', [], function (_export) {
+  return {
+    execute: function() {
+      _export('b', 'c')
+    }
+  }
+})


### PR DESCRIPTION
See [this codepen](https://codepen.io/joeldenning/project/editor/ABpkMK#) for the weird behavior that this fixes.

Also see #1980 where people are doing a double System.import() to work around the current odd behavior.