### PR TITLE
Add deps argument to onload hook

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -62,7 +62,7 @@ _This hook is not available in the s.js minimal loader build._
 
 For tracing functionality this is called on completion or failure of each and every module loaded into the registry.
 
-`err` is defined for any module load error - instantiation (including fetch) errors, execution errors and dependency errors.
+`err` is defined for any module load error at instantiation (including fetch and resolution errors), execution or dependency execution.
 
 `deps` is available for errored modules that did not error on instantiation.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -56,11 +56,15 @@ In both s.js and system.js, resolve is implemented as a synchronous function.
 
 Resolve should return a fully-valid URL for specification compatibility, but this is not enforced.
 
-#### onload(url, error) (sync)
+#### onload(err, id, deps) (sync)
 
 _This hook is not available in the s.js minimal loader build._
 
 For tracing functionality this is called on completion or failure of each and every module loaded into the registry.
+
+`err` is defined for any module load error - instantiation (including fetch) errors, execution errors and dependency errors.
+
+`deps` is available for errored modules that did not error on instantiation.
 
 Such tracing can be used for analysis and to clear the loader registry using the `System.delete(url)` API to enable reloading and hot reloading workflows.
 


### PR DESCRIPTION
As brought up in https://github.com/systemjs/systemjs/issues/1971#issuecomment-524636775, practical usage of `onload` tracing requires the dependencies to be returned.

This updates the tracing API to:

```js
System.onload(err, id, deps)
```

This is a major change due to swapping the err argument order so will go along nicely with v6 as well.