### PR TITLE
Cascading import maps implementation

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -39,6 +39,12 @@ System.constructor.prototype.createContext = function (url) {
 };
 ```
 
+#### prepareImport() -> Promise
+
+This function is called before any `System.import` or dynamic import, returning a Promise that is resolved before continuing to perform the import.
+
+This is used in SystemJS core to ensure that import maps are loaded so that the `System.resolve` function remains synchronous.
+
 #### getRegister() -> [deps: String[], declare: Function]
 
 > This hook is intended for custom module format integrations only.

--- a/docs/import-maps.md
+++ b/docs/import-maps.md
@@ -66,6 +66,10 @@ To more clearly define package folders we can use package folder mappings:
 In this scenario `import 'lodash'` will resolve to `/path/to/lodash/index.js` while `import 'lodash/x'` will
 resolve to `/path/to/lodash/x`.
 
+Note that the _right hand side_ of the import map must always be a valid relative, absolute or full URL (`./x`, `/x`, `https://site.com/x`).
+
+Bare specifiers such as `x` on the right hand side will not match and throw an error.
+
 ### Scopes
 
 Import maps also provide support for scoped mappings, where the mapping should only be applied within
@@ -91,16 +95,44 @@ This can be achieved with scoped import maps:
 </script>
 ```
 
+> Note scopes must end with a trailing `/` to match all subpaths within that path.
+
 Scopes still fallback to applying the global imports, so we only need to do this for imports that are different
 from their global resolutions.
 
+### Composition
+
+_Note: This is an advanced feature, which is not necessary for most use cases._
+
+Multiple import maps are supported with each successive import map composing with the previous one.
+
+When composing import maps, they are combined in order, with the _right hand side_ resolutions of the new import map applying the resolution
+rules of the import map that came before.
+
+This means import maps can reference resolutions from previous import maps:
+
+
+```html
+<script type="systemjs-importmap">
+{
+  "imports": {
+    "x": "/path/to/x.js"
+  }
+}
+</script>
+<script type="systemjs-importmap">
+{
+  "imports": {
+    "y": "x" // resolves to /path/to/x.js
+  }
+}
+</script>
+```
+
 #### Spec and Implementation Feedback
 
-Part of the benefit of giving users a working version of an early spec is being able to get real user feedback on
-the spec.
+Part of the benefit of giving users a working version of an early spec is being able to get real user feedback on the spec.
 
 If you have suggestions, or notice cases where this implementation seems not to be following the spec properly feel free to post an issue.
 
-The edge cases are still being worked out, so there will still be work to do here too.
-
-[Read the full specification for the exact behaviours further](https://github.com/domenic/import-maps/blob/master/spec.md).
+See the [import maps specification](https://github.com/domenic/import-maps/blob/master/spec.md) for exact resolution behaviours.

--- a/minify-extras.sh
+++ b/minify-extras.sh
@@ -1,3 +1,4 @@
+mkdir -p dist/extras
 cp src/extras/* dist/extras/
 cd dist/extras
 rm *.min.js

--- a/src/common.js
+++ b/src/common.js
@@ -1,11 +1,13 @@
 export const hasSelf = typeof self !== 'undefined';
 
+export const hasDocument = typeof document !== 'undefined';
+
 const envGlobal = hasSelf ? self : global;
 export { envGlobal as global };
 
 export let baseUrl;
 
-if (typeof document !== 'undefined') {
+if (hasDocument) {
   const baseEl = document.querySelector('base[href]');
   if (baseEl)
     baseUrl = baseEl.href;

--- a/src/common.js
+++ b/src/common.js
@@ -108,46 +108,42 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
  */
 
 function resolveUrl (relUrl, parentUrl) {
-  return resolveIfNotPlainOrUrl(relUrl, parentUrl) ||
-      relUrl.indexOf(':') !== -1 && relUrl ||
-      resolveIfNotPlainOrUrl('./' + relUrl, parentUrl);
+  return resolveIfNotPlainOrUrl(relUrl, parentUrl) || (relUrl.indexOf(':') !== -1 ? relUrl : resolveIfNotPlainOrUrl('./' + relUrl, parentUrl));
 }
 
-function resolvePackages(pkgs, baseUrl) {
-  var outPkgs = {};
-  for (var p in pkgs) {
-    var value = pkgs[p];
-    // TODO package fallback support
-    if (typeof value !== 'string')
+function objectAssign (to, from) {
+  for (let p in from)
+    to[p] = from[p];
+  return to;
+}
+
+function resolveAndComposePackages (packages, outPackages, baseUrl, parentMap, parentUrl) {
+  for (let p in packages) {
+    const rhs = packages[p];
+    // package fallbacks not currently supported
+    if (typeof rhs !== 'string')
       continue;
-    outPkgs[resolveIfNotPlainOrUrl(p, baseUrl) || p] = resolveUrl(value, baseUrl);
+    const mapped = resolveImportMap(parentMap, resolveIfNotPlainOrUrl(rhs, baseUrl) || rhs, parentUrl);
+    if (!mapped)
+      targetWarning(p, rhs, 'bare specifier did not resolve');
+    else
+      outPackages[p] = mapped;
   }
-  return outPkgs;
 }
 
-export function parseImportMap (json, baseUrl) {
-  const imports = resolvePackages(json.imports, baseUrl) || {};
-  const scopes = {};
-  if (json.scopes) {
-    for (let scopeName in json.scopes) {
-      const scope = json.scopes[scopeName];
-      let resolvedScopeName = resolveUrl(scopeName, baseUrl);
-      if (resolvedScopeName[resolvedScopeName.length - 1] !== '/')
-        resolvedScopeName += '/';
-      scopes[resolvedScopeName] = resolvePackages(scope, baseUrl) || {};
+export function resolveAndComposeImportMap (json, baseUrl, parentMap) {
+  const outMap = { imports: objectAssign({}, parentMap.imports), scopes: objectAssign({}, parentMap.scopes) };
+
+  if (json.imports)
+    resolveAndComposePackages(json.imports, outMap.imports, baseUrl, parentMap, null);
+
+  if (json.scopes)
+    for (let s in json.scopes) {
+      const resolvedScope = resolveUrl(s, baseUrl);
+      resolveAndComposePackages(json.scopes[s], outMap.scopes[resolvedScope] || (outMap.scopes[resolvedScope] = {}), baseUrl, parentMap, resolvedScope);
     }
-  }
 
-  return { imports: imports, scopes: scopes };
-}
-
-export function mergeImportMap(originalMap, newMap) {
-  for (let i in newMap.imports) {
-    originalMap.imports[i] = newMap.imports[i];
-  }
-  for (let i in newMap.scopes) {
-    originalMap.scopes[i] = newMap.scopes[i];
-  }
+  return outMap;
 }
 
 function getMatch (path, matchObj) {
@@ -167,26 +163,23 @@ function applyPackages (id, packages) {
     const pkg = packages[pkgName];
     if (pkg === null) return;
     if (id.length > pkgName.length && pkg[pkg.length - 1] !== '/')
-      console.warn("Invalid package target " + pkg + " for '" + pkgName + "' should have a trailing '/'.");
-    return pkg + id.slice(pkgName.length);
+      targetWarning(pkgName, pkg, "should have a trailing '/'");
+    else
+      return pkg + id.slice(pkgName.length);
   }
 }
 
-export function resolveImportMap (id, parentUrl, importMap) {
-  const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl) || id.indexOf(':') !== -1 && id;
-  if (urlResolved)
-    id = urlResolved;
-  const scopeName = getMatch(parentUrl, importMap.scopes);
-  if (scopeName) {
-    const scopePackages = importMap.scopes[scopeName];
-    const packageResolution = applyPackages(id, scopePackages);
+function targetWarning (match, target, msg) {
+  console.warn("Package target " + msg + ", resolving target '" + target + "' for " + match);
+}
+
+export function resolveImportMap (importMap, resolvedOrPlain, parentUrl) {
+  let scopeUrl = parentUrl && getMatch(parentUrl, importMap.scopes);
+  while (scopeUrl) {
+    const packageResolution = applyPackages(resolvedOrPlain, importMap.scopes[scopeUrl]);
     if (packageResolution)
       return packageResolution;
+    scopeUrl = getMatch(scopeUrl.slice(0, scopeUrl.lastIndexOf('/')), importMap.scopes);
   }
-  return applyPackages(id, importMap.imports) || urlResolved || throwBare(id, parentUrl);
+  return applyPackages(resolvedOrPlain, importMap.imports) || resolvedOrPlain.indexOf(':') !== -1 && resolvedOrPlain;
 }
-
-export function throwBare (id, parentUrl) {
-  throw Error('Unable to resolve bare specifier "' + id + (parentUrl ? '" from ' + parentUrl : '"'));
-}
-

--- a/src/features/import-map.js
+++ b/src/features/import-map.js
@@ -10,12 +10,12 @@
  * 
  * There is no support for dynamic import maps injection currently.
  */
-import { baseUrl, resolveAndComposeImportMap, resolveImportMap, resolveIfNotPlainOrUrl } from '../common.js';
+import { baseUrl, resolveAndComposeImportMap, resolveImportMap, resolveIfNotPlainOrUrl, hasDocument } from '../common.js';
 import { systemJSPrototype } from '../system-core.js';
 
 let importMap = { imports: {}, scopes: {} }, importMapPromise;
 
-if (typeof document !== 'undefined') {
+if (hasDocument) {
   Array.prototype.forEach.call(document.querySelectorAll('script[type="systemjs-importmap"][src]'), function (script) {
     script._j = fetch(script.src).then(function (res) {
       return res.json();
@@ -26,7 +26,7 @@ if (typeof document !== 'undefined') {
 systemJSPrototype.prepareImport = function () {
   if (!importMapPromise) {
     importMapPromise = Promise.resolve();
-    if (typeof document !== 'undefined')
+    if (hasDocument)
       Array.prototype.forEach.call(document.querySelectorAll('script[type="systemjs-importmap"]'), function (script) {
         importMapPromise = importMapPromise.then(function () {
           return (script._j || script.src && fetch(script.src).then(function (resp) { return resp.json(); }) || Promise.resolve(JSON.parse(script.innerHTML)))

--- a/test/fixtures/browser/importmap.json
+++ b/test/fixtures/browser/importmap.json
@@ -11,11 +11,11 @@
     "g/": "https://site.com/"
   },
   "scopes": {
-    "scope-test": {
+    "scope-test/": {
       "maptest": "./contextual-map-dep.js",
       "maptest/": "./contextual-map-dep/"
     },
-    "wasm": {
+    "wasm/": {
       "example": "./wasm/example.js"
     }
   }

--- a/test/fixtures/browser/named-amd.js
+++ b/test/fixtures/browser/named-amd.js
@@ -1,4 +1,4 @@
-define('c', ['exports', './d'], function (exports, b) {
+define('c', ['exports', 'd'], function (exports, b) {
   exports.a = b.b;
 });
 

--- a/test/import-map.js
+++ b/test/import-map.js
@@ -1,33 +1,50 @@
 import './fixtures/tracing.js';
-import { parseImportMap, resolveImportMap, mergeImportMap } from '../src/common.js';
+import { resolveAndComposeImportMap, resolveImportMap, resolveIfNotPlainOrUrl } from '../src/common.js';
 import assert from 'assert';
 
-describe('Import Maps', function () {
-  let importMap
+// function resolveImportMap (importMap, resolvedOrPlain, parentUrl);
 
-  beforeEach(function () {
-    importMap = parseImportMap({
-      imports: {
-        "x": "/y",
-        "x/": "/src/x/",
-        "p": "t",
-        "p/": "t/",
-        "m": "./m/index.js",
-        "m/": "./m/",
-        "https://site.com/x": "/x.js",
-        "r": "r"
-      },
-      scopes: {
-        "/scope/": {
-          "x/": "y/"
-        }
+function doResolveImportMap (id, parentUrl, importMap) {
+  return resolveImportMap(importMap, resolveIfNotPlainOrUrl(id, parentUrl) || id, parentUrl);
+}
+
+
+describe('Import Maps', function () {
+  const firstImportMap = resolveAndComposeImportMap({
+    imports: {
+      "t": "./src/t",
+      "t/": "./src/t/",
+      "r": "./src/r"
+    },
+    scopes: {
+      "/": {
+        "y/": "./src/y/"
       }
-    }, 'https://sample.com/src/');
-  });
+    }
+  }, 'https://sample.com/', { imports: {}, scopes: {} });
+
+  const baseImportMap = resolveAndComposeImportMap({
+    imports: {
+      "x": "/y",
+      "x/": "/src/x/",
+      "p": "t",
+      "p/": "t/",
+      "m": "./m/index.js",
+      "m/": "./m/",
+      "https://site.com/x": "/x.js",
+      "r": "r",
+      "g": "./g"
+    },
+    scopes: {
+      "/scope/": {
+        "x/": "y/"
+      }
+    }
+  }, 'https://sample.com/src/', firstImportMap);
 
   it('Throws for unknown', function () {
     try {
-      resolveImportMap('z', 'https://site.com', importMap);
+      doResolveImportMap('z', 'https://site.com', baseImportMap);
     }
     catch (e) {
       assert.equal(e.message, 'Unable to resolve bare specifier "z" from https://site.com');
@@ -35,24 +52,24 @@ describe('Import Maps', function () {
   });
 
   it('Can map URLs', function () {
-    assert.equal(resolveImportMap('/x', 'https://site.com/', importMap), 'https://sample.com/x.js');
+    assert.equal(doResolveImportMap('/x', 'https://site.com/', baseImportMap), 'https://sample.com/x.js');
   });
 
   it('Resolves packages with main sugar', function () {
-    assert.equal(resolveImportMap('x', 'https://site.com', importMap), 'https://sample.com/y');
+    assert.equal(doResolveImportMap('x', 'https://site.com', baseImportMap), 'https://sample.com/y');
   });
 
   it('Resolves subpaths with main sugar', function () {
-    assert.equal(resolveImportMap('x/z', 'https://site.com', importMap), 'https://sample.com/src/x/z');
+    assert.equal(doResolveImportMap('x/z', 'https://site.com', baseImportMap), 'https://sample.com/src/x/z');
   });
 
   it('Resolves packages with a path', function () {
-    assert.equal(resolveImportMap('p/r', 'https://site.com', importMap), 'https://sample.com/src/t/r');
+    assert.equal(doResolveImportMap('p/r', 'https://site.com', baseImportMap), 'https://sample.com/src/t/r');
   });
 
   it('Throws resolving a package with no main', function () {
     try {
-      resolveImportMap('p', 'https://site.com', importMap);
+      doResolveImportMap('p', 'https://site.com', baseImportMap);
     }
     catch (e) {
       assert.equal(e.message, 'Package p has no main');
@@ -60,63 +77,71 @@ describe('Import Maps', function () {
   });
 
   it('Resolves packages with a main', function () {
-    assert.equal(resolveImportMap('m', 'https://site.com', importMap), 'https://sample.com/src/m/index.js');
+    assert.equal(doResolveImportMap('m', 'https://site.com', baseImportMap), 'https://sample.com/src/m/index.js');
   });
 
   it('Resolves package subpaths for a main', function () {
-    assert.equal(resolveImportMap('m/s', 'https://site.com', importMap), 'https://sample.com/src/m/s');
+    assert.equal(doResolveImportMap('m/s', 'https://site.com', baseImportMap), 'https://sample.com/src/m/s');
   });
 
   it('Resolves scoped packages', function () {
-    assert.equal(resolveImportMap('x', 'https://sample.com/scope/y', importMap), 'https://sample.com/y');
+    assert.equal(doResolveImportMap('x', 'https://sample.com/scope/y', baseImportMap), 'https://sample.com/y');
   });
 
   it('Resolves scoped package subpaths', function () {
-    assert.equal(resolveImportMap('x/sub', 'https://sample.com/scope/y', importMap), 'https://sample.com/src/y/sub');
+    assert.equal(doResolveImportMap('x/sub', 'https://sample.com/scope/y', baseImportMap), 'https://sample.com/src/y/sub');
   });
 
   it('Overrides package resolution when two import maps define the same module', function () {
-    const secondMap = parseImportMap({
+    const importMap = resolveAndComposeImportMap({
       imports: {
-        r: 'overridden-r',
+        r: './overridden-r',
       }
-    }, 'https://sample.com/src/');
-    mergeImportMap(importMap, secondMap);
-    assert.equal(resolveImportMap('r', 'https://site.com', importMap), 'https://sample.com/src/overridden-r');
+    }, 'https://sample.com/src/', baseImportMap);
+    assert.equal(doResolveImportMap('r', 'https://site.com', importMap), 'https://sample.com/src/overridden-r');
   });
 
   it('Adds to an existing import map when there are two import maps', function () {
-    const secondMap = parseImportMap({
+    const importMap = resolveAndComposeImportMap({
       imports: {
         g: 'g',
       }
-    }, 'https://sample.com/src/');
-    mergeImportMap(importMap, secondMap);
-    assert.equal(resolveImportMap('g', 'https://site.com', importMap), 'https://sample.com/src/g');
+    }, 'https://sample.com/src/', baseImportMap);
+    assert.equal(doResolveImportMap('g', 'https://site.com', importMap), 'https://sample.com/src/g');
+  });
+
+  it('Supports scopes as exact ids', function () {
+    const importMap = resolveAndComposeImportMap({
+      scopes: {
+        "/scope": {
+          "x/": "./z/"
+        }
+      }
+    }, 'https://sample.com/src/', baseImportMap);
+    assert.equal(doResolveImportMap('x/file.js', 'https://sample.com/scope', importMap), 'https://sample.com/src/z/file.js');
+    assert.equal(doResolveImportMap('x/file.js', 'https://sample.com/scope/', importMap), 'https://sample.com/src/y/file.js');
   });
 
   it('Overrides an import map scope when two import maps define the same scope', function () {
-    const secondMap = parseImportMap({
+    const importMap = resolveAndComposeImportMap({
       scopes: {
-        "/scope": {
-          "x/": "z/"
+        "/scope/": {
+          "x/": "./z/"
         }
       }
-    }, 'https://sample.com/src/');
-    mergeImportMap(importMap, secondMap);
-    assert.equal(resolveImportMap('x/file.js', 'https://sample.com/scope/something', importMap), 'https://sample.com/src/z/file.js');
+    }, 'https://sample.com/src/', baseImportMap);
+    assert.equal(doResolveImportMap('x/file.js', 'https://sample.com/scope/something', importMap), 'https://sample.com/src/z/file.js');
   });
 
   it('Adds an import map scope when two import maps are merged', function () {
-    const secondMap = parseImportMap({
+    const importMap = resolveAndComposeImportMap({
       scopes: {
-        "/other-scope": {
+        "/other-scope/": {
           "f": "/other-scope-path/f.js"
         }
       }
-    }, 'https://sample.com/src/');
-    mergeImportMap(importMap, secondMap);
-    assert.equal(resolveImportMap('f', 'https://sample.com/other-scope/something', importMap), 'https://sample.com/other-scope-path/f.js');
+    }, 'https://sample.com/src/', baseImportMap);
+    assert.equal(doResolveImportMap('f', 'https://sample.com/other-scope/something', importMap), 'https://sample.com/other-scope-path/f.js');
   });
 
 });


### PR DESCRIPTION
This implements https://github.com/systemjs/systemjs/issues/1999 for cascading import maps resolution, with the implementation behaviours as described in https://github.com/systemjs/systemjs/issues/1999#issuecomment-525359382.

In addition this fixes https://github.com/systemjs/systemjs/issues/2007 that scopes must end in a trailing slash.

The breaking changes are effectively:

1. Scopes must end in a trailing slash.
2. Bare specifiers on the RHS of an import map are no longer supported unless in a cascade.