### PR TITLE
Support registry delete returning update function

### DIFF
--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -75,8 +75,8 @@ systemJSPrototype.delete = function (id) {
     if (!load || load.e !== null || load.E)
       return false;
     // add back the old setters
-    load.i.forEach(setter => {
-      if (importerSetters.indexOf(setter) === -1) {
+    importerSetters.forEach(setter => {
+      if (load.i.indexOf(setter) === -1) {
         load.i.push(setter);
         setter(load.ns);
       }

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -39,8 +39,8 @@ systemJSPrototype.set = function (id, module) {
   
   Object.assign(load, {
     n: ns,
-    I: done,
-    L: done,
+    I: undefined,
+    L: undefined,
     C: done
   });
   return ns;

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -77,7 +77,7 @@ systemJSPrototype.delete = function (id) {
     // add back the old setters
     importerSetters.forEach(setter => {
       load.i.push(setter);
-      setter(load.ns);
+      setter(load.n);
     });
     importerSetters = null;
   };

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -12,8 +12,6 @@ systemJSPrototype.get = function (id) {
 };
 
 systemJSPrototype.set = function (id, module) {
-  if (this[REGISTRY][id]) return false;
-
   let ns;
   if (toStringTag && module[toStringTag] === 'Module') {
     ns = module;
@@ -25,19 +23,26 @@ systemJSPrototype.set = function (id, module) {
   }
 
   const done = Promise.resolve(ns);
-  this[REGISTRY][id] = {
+
+  const load = this[REGISTRY][id] || (this[REGISTRY][id] = {
     id: id,
     i: [],
-    n: ns,
-    I: done,
-    L: done,
     h: false,
     d: [],
     e: null,
     er: undefined,
-    E: undefined,
+    E: undefined
+  });
+
+  if (load.e || load.E)
+    return false;
+  
+  Object.assign(load, {
+    n: ns,
+    I: done,
+    L: done,
     C: done
-  };
+  });
   return ns;
 };
 

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -60,7 +60,7 @@ systemJSPrototype.delete = function (id) {
   if (!load || load.e !== null || load.E)
     return false;
 
-  const importerSetters = load.i;
+  let importerSetters = load.i;
   // remove from importerSetters
   // (release for gc)
   if (load.d)
@@ -72,15 +72,14 @@ systemJSPrototype.delete = function (id) {
   delete registry[id];
   return function () {
     const load = registry[id];
-    if (!load || load.e !== null || load.E)
+    if (!load || !importerSetters || load.e !== null || load.E)
       return false;
     // add back the old setters
     importerSetters.forEach(setter => {
-      if (load.i.indexOf(setter) === -1) {
-        load.i.push(setter);
-        setter(load.ns);
-      }
+      load.i.push(setter);
+      setter(load.ns);
     });
+    importerSetters = null;
   };
 };
 

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -182,7 +182,7 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
     d: undefined,
     // execution function
     // set to NULL immediately after execution (or on any failure) to indicate execution has happened
-    // in such a case, pC should be used, and pLo, pLi will be emptied
+    // in such a case, C should be used, and E, I, L will be emptied
     e: undefined,
 
     // On execution we have populated:
@@ -191,7 +191,7 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
     // in the case of TLA, the execution promise
     E: undefined,
 
-    // On execution, pLi, pLo, e cleared
+    // On execution, L, I, E cleared
 
     // Promise for top-level completion
     C: undefined


### PR DESCRIPTION
With this API the registry delete function will return an update function that can be called later on once the module is reimported.

When that happens, any modules that previously depended on the deleted module will get rebound to the new module, effectively using ES module live bindings to do this.

The `has` API function is also updated to return true on in-progress loads.

Will be useful for fully-live hot reloading workflows, as in https://github.com/systemjs/systemjs/pull/2014.