### PR TITLE
Patching prepareImport before loading script modules. Resolves #2024.

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -1,6 +1,6 @@
+import './features/import-map.js';
 import './features/script-load.js';
 import './features/worker-load.js';
 import './extras/global.js';
 import './extras/module-types.js';
-import './features/import-map.js';
 import './features/registry.js';

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -191,4 +191,10 @@ suite('SystemJS Standard Tests', function() {
     assert.ok(System.has(resolved));
     assert.equal(System.get(resolved).hello, 'there');
   });
+
+  test('should load <script type=systemjs-module> that is in the dom before systemjs is loaded', function () {
+    const resolved = System.resolve('/test/fixtures/browser/systemjs-module-early.js');
+    assert.ok(System.has(resolved));
+    assert.equal(System.get(resolved).hi, 'bye');
+  })
 });

--- a/test/fixtures/browser/systemjs-module-early.js
+++ b/test/fixtures/browser/systemjs-module-early.js
@@ -1,0 +1,7 @@
+System.register([], function(_export) {
+  return {
+    execute: function () {
+      _export('hi', 'bye');
+    }
+  };
+});

--- a/test/test.html
+++ b/test/test.html
@@ -19,6 +19,7 @@
 	<script src="../node_modules/mocha/mocha.js"></script>
 
 	<script type="systemjs-importmap" src="fixtures/browser/importmap.json"></script>
+	<script type="systemjs-module" src="/test/fixtures/browser/systemjs-module-early.js"></script>
 	<script src="../dist/system.js"></script>
 	<script type="systemjs-module" src="/test/fixtures/browser/systemjs-module-script.js"></script>
 	<script type="systemjs-module" src="import:/test/fixtures/browser/systemjs-module-script2.js"></script>


### PR DESCRIPTION
See #2024 

The root cause of the bug was order of execution. In 6.1.0, [Line 531](https://github.com/systemjs/systemjs/blob/c08c92dcdb0850b999b6cf4c180702e01ae8b04d/dist/system.js#L531) needs to execute *after* [line 760](https://github.com/systemjs/systemjs/blob/c08c92dcdb0850b999b6cf4c180702e01ae8b04d/dist/system.js#L760). So that `prepareImport` is patched before the first `System.import()` occurs. The bug was to rearrange the order of execution.

I reviewed all the features that import-map.js used to execute after but now is executing before. And none of them patch `System.resolve` or `System.prepareImport`, so I don't think there will be any side effects of changing up the order of execution.