### PR TITLE
Fixing bug with AMD extra. Resolves #2026.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -69,11 +69,11 @@
     systemRegister.apply(this, arguments);
   };
 
-  const prepareImport = systemPrototype.prepareImport;
-  systemPrototype.prepareImport = function() {
+  const instantiate = systemPrototype.instantiate;
+  systemPrototype.instantiate = function() {
     // Reset "currently executing script"
     amdDefineDeps = null;
-    return prepareImport.apply(this, arguments);
+    return instantiate.apply(this, arguments);
   };
 
   const getRegister = systemPrototype.getRegister;

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -69,6 +69,13 @@
     systemRegister.apply(this, arguments);
   };
 
+  const prepareImport = systemPrototype.prepareImport;
+  systemPrototype.prepareImport = function() {
+    // Reset "currently executing script"
+    amdDefineDeps = null;
+    return prepareImport.apply(this, arguments);
+  };
+
   const getRegister = systemPrototype.getRegister;
   systemPrototype.getRegister = function () {
     const register = getRegister.call(this);

--- a/test/browser/amd.js
+++ b/test/browser/amd.js
@@ -65,4 +65,12 @@ suite('AMD tests', function () {
     });
   });
 
+  test('loading single named AMD module after manually calling define. See https://github.com/systemjs/systemjs/issues/2026#issuecomment-532022465', function () {
+    define('inline-define', [], function () {
+      return "inline define value";
+    });
+    return System.import('fixtures/amd-named-simple.js').then(function (m) {
+      assert.equal(m.default, "AMD Simple");
+    });
+  });
 });

--- a/test/fixtures/browser/amd-named-simple.js
+++ b/test/fixtures/browser/amd-named-simple.js
@@ -1,0 +1,3 @@
+define('amd-named-simple', [], function () {
+  return "AMD Simple";
+});


### PR DESCRIPTION
Resolves #2026 

If an inline script calls `define('name', ...)` and then the next `System.import()` calls `define('other-name', ...)`, SystemJS currently accidentally counts the first call to `define()` to be the export for the System.import(), even though it's not even in the same file. This behavior is related to the desired behavior of having SystemJS use the first named register be the register for the overall module.

To solve this, I'm resetting things at the beginning of each System.import() so that inline scripts calling System.register or define won't interfere with loading a module with System.import().

Note that the newly added test fails without the changes to the amd extra, so it's a good reproduction case.