### PR TITLE
Fix old browsers not supporting `forEach` in `querySelectorAll` result

### DIFF
--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -53,9 +53,10 @@ if (hasDocument) {
 }
 
 function loadScriptModules() {
-  document.querySelectorAll('script[type=systemjs-module]').forEach(function (script) {
-    if (script.src) {
-      System.import(script.src.slice(0, 7) === 'import:' ? script.src.slice(7) : resolveUrl(script.src, baseUrl));
-    }
-  });
+  Array.prototype.forEach.call(
+    document.querySelectorAll('script[type=systemjs-module]'), function (script) {
+      if (script.src) {
+        System.import(script.src.slice(0, 7) === 'import:' ? script.src.slice(7) : resolveUrl(script.src, baseUrl));
+      }
+    });
 }


### PR DESCRIPTION
Replace `document.querySelectorAll(...).forEach` with `Array.prototype.forEach.call(document.querySelectorAll, ...)` due to old browsers (ex: IE 11) not supporting [`entries|forEach|keys|values`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Browser_compatibility) methods in NodeList.