### PR TITLE
Handle resolution of relative URLs LHS in import maps

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -121,6 +121,7 @@ function objectAssign (to, from) {
 
 function resolveAndComposePackages (packages, outPackages, baseUrl, parentMap, parentUrl) {
   for (let p in packages) {
+    const resolvedLhs = resolveIfNotPlainOrUrl(p, baseUrl) || p;
     const rhs = packages[p];
     // package fallbacks not currently supported
     if (typeof rhs !== 'string')
@@ -129,7 +130,7 @@ function resolveAndComposePackages (packages, outPackages, baseUrl, parentMap, p
     if (!mapped)
       targetWarning(p, rhs, 'bare specifier did not resolve');
     else
-      outPackages[p] = mapped;
+      outPackages[resolvedLhs] = mapped;
   }
 }
 

--- a/test/import-map.js
+++ b/test/import-map.js
@@ -12,6 +12,7 @@ function doResolveImportMap (id, parentUrl, importMap) {
 describe('Import Maps', function () {
   const firstImportMap = resolveAndComposeImportMap({
     imports: {
+      "./asdf": "./asdf-asdf",
       "t": "./src/t",
       "t/": "./src/t/",
       "r": "./src/r"
@@ -53,6 +54,10 @@ describe('Import Maps', function () {
 
   it('Can map URLs', function () {
     assert.equal(doResolveImportMap('/x', 'https://site.com/', baseImportMap), 'https://sample.com/x.js');
+  });
+
+  it('Can map relative URLs', function () {
+    assert.equal(doResolveImportMap('/asdf', 'https://sample.com/', baseImportMap), 'https://sample.com/asdf-asdf');
   });
 
   it('Resolves packages with main sugar', function () {


### PR DESCRIPTION
Resolves #2038 in resolving the LHS in maps (when not a bare specifier) relative to the baseURL.

This baseURL LHS normalization is used to resolve both imports and in scopes, as per the spec.