### PR TITLE
Waiting for extras before loading systemjs-module scripts. Resolves #2040

### DIFF
--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -49,7 +49,7 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
 
 if (hasDocument) {
   window.addEventListener('DOMContentLoaded', loadScriptModules);
-  setTimeout(loadScriptModules)
+  setTimeout(loadScriptModules);
 }
 
 function loadScriptModules() {

--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -49,7 +49,7 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
 
 if (hasDocument) {
   window.addEventListener('DOMContentLoaded', loadScriptModules);
-  loadScriptModules();
+  setTimeout(loadScriptModules)
 }
 
 function loadScriptModules() {


### PR DESCRIPTION
See #2040 

The solution assumes that `setTimeout` will grant enough time for all the systemjs extras scripts to be loaded and executed. I don't know enough about how the browser deals with initially loaded scripts and the event loop to know whether that assumption holds.

Do you know if that's a reliable thing we can depend on? I have verified that it seems to fix things in the codepen i created for 2040.