### PR TITLE
Fix for named-register extra. Resolves #2040.

### DIFF
--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -6,12 +6,12 @@
  * System.register('x', ...) can be imported as System.import('x')
  */
 (function () {
-  System.registerRegistry = Object.create(null);
+  setRegisterRegistry(System);
   const systemJSPrototype = System.constructor.prototype;
   const constructor = System.constructor;
   const SystemJS = function () {
     constructor.call(this);
-    this.registerRegistry = Object.create(null);
+    setRegisterRegistry(this);
   };
   SystemJS.prototype = systemJSPrototype;
   System.constructor = SystemJS;
@@ -20,6 +20,10 @@
 
   function clearFirstNamedDefine () {
     firstNamedDefine = null;
+  }
+
+  function setRegisterRegistry(systemInstance) {
+    systemInstance.registerRegistry = Object.create(null);
   }
 
   const register = systemJSPrototype.register;

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -6,15 +6,15 @@
  * System.register('x', ...) can be imported as System.import('x')
  */
 (function () {
+  System.registerRegistry = Object.create(null);
   const systemJSPrototype = System.constructor.prototype;
-
   const constructor = System.constructor;
   const SystemJS = function () {
     constructor.call(this);
     this.registerRegistry = Object.create(null);
   };
   SystemJS.prototype = systemJSPrototype;
-  System = new SystemJS();
+  System.constructor = SystemJS;
 
   let firstNamedDefine;
 


### PR DESCRIPTION
Another potential fix for #2040. This directly addresses the problem that causes the bug in #2040, but doesn't address the deeper underlying issues related to `System.import()` being called before all the extras are loaded.