### PR TITLE
Access the `System` variable through `global` in Extras

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -2,6 +2,7 @@
  * Support for AMD loading
  */
 (function (global) {
+  const System = global.System;
   const systemPrototype = System.constructor.prototype;
 
   const emptyInstantiation = [[], function () { return {} }];

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -4,7 +4,7 @@
  * (Included by default in system.js build)
  */
 (function (global) {
-
+const System = global.System;
 const systemJSPrototype = System.constructor.prototype;
 
 // safari unpredictably lists some new globals first or second in object order

--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -2,7 +2,8 @@
  * Loads JSON, CSS, Wasm module types based on file extensions
  * Supports application/javascript falling back to JS eval
  */
-(function() {
+(function(global) {
+  const System = global.System;
   const systemPrototype = System.constructor.prototype;
   const instantiate = systemPrototype.instantiate;
 
@@ -92,4 +93,4 @@
       throw Error(msg + ', loading ' + url + (parent ? ' from ' + parent : ''));
     }
   };
-})();
+})(typeof self !== 'undefined' ? self : global);

--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -1,7 +1,8 @@
 /*
  * Named exports support for legacy module formats in SystemJS 2.0
  */
-(function () {
+(function (global) {
+  const System = global.System;
   const systemPrototype = System.constructor.prototype;
   
   // hook System.register to know the last declaration binding
@@ -54,4 +55,4 @@
     };
     return register;
   };
-})();
+})(typeof self !== 'undefined' ? self : global);

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -5,7 +5,8 @@
  * Names are written to the registry as-is
  * System.register('x', ...) can be imported as System.import('x')
  */
-(function () {
+(function (global) {
+  const System = global.System;
   const systemJSPrototype = System.constructor.prototype;
 
   const constructor = System.constructor;
@@ -53,4 +54,4 @@
   systemJSPrototype.getRegister = function () {
     return firstNamedDefine || getRegister.call(this);
   }
-})();
+})(typeof self !== 'undefined' ? self : global);

--- a/src/extras/transform.js
+++ b/src/extras/transform.js
@@ -1,7 +1,8 @@
 /*
  * Support for a "transform" loader interface
  */
-(function () {
+(function (global) {
+  const System = global.System;
   const systemJSPrototype = System.constructor.prototype;
 
   const instantiate = systemJSPrototype.instantiate;
@@ -29,4 +30,4 @@
   systemJSPrototype.transform = function (_id, source) {
     return source;
   };
-})();
+})(typeof self !== 'undefined' ? self : global);

--- a/src/extras/use-default.js
+++ b/src/extras/use-default.js
@@ -2,7 +2,8 @@
  * Interop for AMD modules to return the direct AMD binding instead of a
  * `{ default: amdModule }` object from `System.import`
  */
-(function () {
+(function (global) {
+  const System = global.System;
   const systemPrototype = System.constructor.prototype;
   const originalImport = systemPrototype.import;
 
@@ -11,4 +12,4 @@
       return ns.__useDefault ? ns.default : ns;
     });
   };
-})()
+})(typeof self !== 'undefined' ? self : global);


### PR DESCRIPTION
Hi,

Is it ok for the "extras" to access `System` from the "global" passed in, instead of the `System` found in the current execution context? Seem the correct thing to me, if you don't care.

I just changed the ` src/extras/*` files, but something seens that was not built in the last commit https://github.com/systemjs/systemjs/compare/master...esroyo:master#diff-5d8dcd1a2a96334214577c42caccb58f

Thanks so much