### PR TITLE
Docs deprecate use-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ The following [pluggable extras](dist/extras) can be dropped in with either the 
 * [Named exports](dist/extras/named-exports.js) convenience extension support for global and AMD module formats (`import { x } from './global.js'` instead of `import G from './global.js'; G.x`)
 * [Named register](dist/extras/named-register.js) supports `System.register('name', ...)` named bundles which can then be imported as `System.import('name')` (as well as AMD named define support)
 * [Transform loader](dist/extras/transform.js) support, using fetch and eval, supporting a hookable `loader.transform`
-* [Use default](dist/extras/use-default.js) provides a convenience interop for AMD modules to return the direct AMD
-  binding instead of a `{ default: amdModule }` object from `System.import`.
 
 The following extras are included in system.js loader by default, and can be added to the s.js loader for a smaller tailored footprint:
 


### PR DESCRIPTION
This removes mention of the use-default extension from the docs, in line with concerns in https://github.com/systemjs/systemjs/issues/2045.

Full deprecation can then happen in a subsequent major but there is no rush.