### PR TITLE
Fixing bug where named-exports didn't work on named registers. Resolves #2073.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -137,6 +137,7 @@
   function insertToRegisterRegistry(name, define) {
     // We must call System.getRegister() here to give other extras, such as the named-exports extra,
     // a chance to modify the define before it's put into the registerRegistry.
+    // See https://github.com/systemjs/systemjs/issues/2073
     tempRegister = define;
     System.registerRegistry[name] = System.getRegister();
     tempRegister = null;

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -10,7 +10,7 @@
     throw Error('AMD require not supported.');
   }
 
-  let tempRegister;
+  let tmpRegister;
 
   function emptyFn () {}
 
@@ -80,8 +80,8 @@
 
   const getRegister = systemPrototype.getRegister;
   systemPrototype.getRegister = function () {
-    if (tempRegister)
-      return tempRegister;
+    if (tmpRegister)
+      return tmpRegister;
 
     const register = getRegister.call(this);
     // if its an actual System.register leave it
@@ -104,14 +104,14 @@
       if (amdDefineDeps) {
         if (!System.registerRegistry)
           throw Error('Include the named register extension for SystemJS named AMD support.');
-        insertToRegisterRegistry(name, createAMDRegister(deps, execute));
+        addToRegisterRegistry(name, createAMDRegister(deps, execute));
         amdDefineDeps = [];
         amdDefineExec = emptyFn;
         return;
       }
       else {
         if (System.registerRegistry)
-          insertToRegisterRegistry(name, createAMDRegister([].concat(deps), execute));
+          addToRegisterRegistry(name, createAMDRegister([].concat(deps), execute));
         name = deps;
         deps = execute;
       }
@@ -134,12 +134,12 @@
   };
   global.define.amd = {};
 
-  function insertToRegisterRegistry(name, define) {
+  function addToRegisterRegistry(name, define) {
     // We must call System.getRegister() here to give other extras, such as the named-exports extra,
     // a chance to modify the define before it's put into the registerRegistry.
     // See https://github.com/systemjs/systemjs/issues/2073
-    tempRegister = define;
+    tmpRegister = define;
     System.registerRegistry[name] = System.getRegister();
-    tempRegister = null;
+    tmpRegister = null;
   }
 })(typeof self !== 'undefined' ? self : global);

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -135,6 +135,8 @@
   global.define.amd = {};
 
   function insertToRegisterRegistry(name, define) {
+    // We must call System.getRegister() here to give other extras, such as the named-exports extra,
+    // a chance to modify the define before it's put into the registerRegistry.
     tempRegister = define;
     System.registerRegistry[name] = System.getRegister();
     tempRegister = null;

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -26,6 +26,7 @@ suite('Named System.register', function() {
     });
   });
 
+  // https://github.com/systemjs/systemjs/issues/2073
   test('Loading a named AMD module with named-exports enabled (no dependencies)', function () {
     define('named-amd-define-no-deps', [], function() {
       return {foo: 'bar'};
@@ -38,6 +39,7 @@ suite('Named System.register', function() {
     });
   });
 
+  // https://github.com/systemjs/systemjs/issues/2073
   test('Loading a named AMD module with named-exports enabled (with dependencies)', function () {
     define('named-amd-define-with-deps', ['b'], function() {
       return {foo: 'bar'};

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -25,4 +25,28 @@ suite('Named System.register', function() {
       assert.equal(m.b, 'c');
     });
   });
+
+  test('Loading a named AMD module with named-exports enabled (no dependencies)', function () {
+    define('named-amd-define-no-deps', [], function() {
+      return {foo: 'bar'};
+    });
+
+    return System.import('named-amd-define-no-deps').then(function (m) {
+      assert.ok(m.default);
+      assert.ok(m.default.foo);
+      assert.ok(m.foo);
+    });
+  });
+
+  test('Loading a named AMD module with named-exports enabled (with dependencies)', function () {
+    define('named-amd-define-with-deps', ['b'], function() {
+      return {foo: 'bar'};
+    });
+
+    return System.import('named-amd-define-with-deps').then(function (m) {
+      assert.ok(m.default);
+      assert.ok(m.default.foo);
+      assert.ok(m.foo);
+    });
+  });
 });


### PR DESCRIPTION
Resolves #2073. I verified that this adds 49 bytes to the amd.min.js extra.