### PR TITLE
disable `eval` for css files

### DIFF
--- a/src/extras/transform.js
+++ b/src/extras/transform.js
@@ -6,7 +6,7 @@
 
   const instantiate = systemJSPrototype.instantiate;
   systemJSPrototype.instantiate = function (url, parent) {
-    if (url.slice(-5) === '.wasm')
+    if (url.slice(-5) === '.wasm' || url.slice(-4) === '.css')
       return instantiate.call(this, url, parent);
 
     const loader = this;

--- a/test/browser/transform.js
+++ b/test/browser/transform.js
@@ -74,6 +74,14 @@ suite('Transform Loader', function() {
         assert.equal(m.exampleExport(1), 2);
       });
     });
+    
+    test('Loading CSS', function () {
+      return System.import('./fixtures/css-modules/a.css')
+      .then(function (m) {
+        assert.ok(m);
+        assert.ok(m.default instanceof CSSStyleSheet);
+      });
+    });
 
     test('Verification', function () {
       assert.equal(translateCnt, 8);


### PR DESCRIPTION
`eval` for css files caught to error