### PR TITLE
Ensure that __esModule is copied to ns even if it isn't enumerable.

### DIFF
--- a/src/system-core.js
+++ b/src/system-core.js
@@ -111,7 +111,7 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
         }
 
         if (name.__esModule) {
-          ns.__esModule = true;
+          ns.__esModule = name.__esModule;
         }
       }
       if (changed)

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -111,7 +111,7 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
         }
 
         if (name.__esModule) {
-          ns.__esModule = true
+          ns.__esModule = true;
         }
       }
       if (changed)

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -109,6 +109,10 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
             changed = true;
           }
         }
+
+        if (name.__esModule) {
+          ns.__esModule = true
+        }
       }
       if (changed)
         for (let i = 0; i < importerSetters.length; i++)

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -196,5 +196,12 @@ suite('SystemJS Standard Tests', function() {
     const resolved = System.resolve('/test/fixtures/browser/systemjs-module-early.js');
     assert.ok(System.has(resolved));
     assert.equal(System.get(resolved).hi, 'bye');
-  })
+  });
+
+  test('non-enumerable __esModule property export (issue 2090)', function () {
+    return System.import('fixtures/__esModule.js').then(function (m) {
+      // Even though __esModule is not enumerable on the exported object, it should be preserved on the systemjs namespace
+      assert.ok(m.__esModule);
+    });
+  });
 });

--- a/test/fixtures/browser/__esModule.js
+++ b/test/fixtures/browser/__esModule.js
@@ -1,0 +1,9 @@
+System.register([], function (_export) {
+  const obj = {};
+
+  Object.defineProperty(obj, '__esModule', {enumerable: false, value: true});
+
+  _export(obj);
+
+  return {};
+});


### PR DESCRIPTION
Resolves #2090. Webpack sets the __esModule property as [not enumerable](https://github.com/csr632/systemjs-issue-2090/blob/72132d1d04241871de00476a977ba6eacb6b7b87/dist/math-add.js#L54) (note that when you don't define enumerability that it defaults to false). Since it's not enumerable, it doesn't end up on the systemjs `ns` object. This is problematic because that flag is needed when webpack bundles interop with each other.