### PR TITLE
Add link to introduction video

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The [systemjs-examples repo](https://github.com/systemjs/systemjs-examples) cont
 
 ## Overview
 
+[Introduction video](https://www.youtube.com/watch?v=AmdKF2UhFzw)
+
 SystemJS provides two hookable base builds:
 
 #### 1. s.js minimal loader


### PR DESCRIPTION
I've had a couple people tell me that they found this video useful, so I thought I'd propose it as part of the Readme. Would not be offended if there are reasons not to merge this.

@guybedford thoughts?