### PR TITLE
Omit setTimeout milliseconds (saves bytes).

### DIFF
--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -35,7 +35,7 @@
     this.registerRegistry[name] = define;
     if (!firstNamedDefine) {
       firstNamedDefine = define;
-      setTimeout(clearFirstNamedDefine, 0);
+      setTimeout(clearFirstNamedDefine);
     }
     return register.apply(this, arguments);
   };


### PR DESCRIPTION
Zero milliseconds is the default. https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout