### PR TITLE
Fixing race conditions with named register modules. Resolves #2111.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -103,8 +103,7 @@
     if (!_amdDefineDeps)
       return register || emptyInstantiation;
 
-    const registration = createAMDRegister(_amdDefineDeps, amdDefineExec);
-    return registration;
+    return createAMDRegister(_amdDefineDeps, amdDefineExec);
   };
   let amdDefineDeps, amdDefineExec;
   global.define = function (name, deps, execute) {

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -83,22 +83,27 @@
     if (tmpRegister)
       return tmpRegister;
 
+    const _firstNamedDefine = firstNamedDefine;
+    firstNamedDefine = null;
+
     const register = getRegister.call(this);
     // if its an actual System.register leave it
     if (register && register[1] === lastRegisterDeclare)
       return register;
 
+    const _amdDefineDeps = amdDefineDeps;
+    amdDefineDeps = null;
+
     // If the script registered a named module, return that module instead of re-instantiating it.
-    if (firstNamedDefine)
-      return firstNamedDefine;
+    if (_firstNamedDefine)
+      return _firstNamedDefine;
 
     // otherwise AMD takes priority
     // no registration -> attempt AMD detection
-    if (!amdDefineDeps)
+    if (!_amdDefineDeps)
       return register || emptyInstantiation;
 
-    const registration = createAMDRegister(amdDefineDeps, amdDefineExec);
-    amdDefineDeps = null;
+    const registration = createAMDRegister(_amdDefineDeps, amdDefineExec);
     return registration;
   };
   let amdDefineDeps, amdDefineExec;
@@ -141,9 +146,6 @@
   function addToRegisterRegistry(name, define) {
     if (!firstNamedDefine) {
       firstNamedDefine = define;
-      setTimeout(function () {
-        firstNamedDefine = null;
-      });
     }
 
     // We must call System.getRegister() here to give other extras, such as the named-exports extra,

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -61,9 +61,8 @@
     // Calling getRegister() because other extras need to know it was called so they can perform side effects
     const register = getRegister.call(this);
 
-    const _firstNamedDefine = firstNamedDefine;
+    const result = firstNamedDefine || register;
     firstNamedDefine = null;
-
-    return _firstNamedDefine || register;
+    return result;
   }
 })(typeof self !== 'undefined' ? self : global);

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -35,7 +35,6 @@
     this.registerRegistry[name] = define;
     if (!firstNamedDefine) {
       firstNamedDefine = define;
-      setTimeout(clearFirstNamedDefine);
     }
     return register.apply(this, arguments);
   };
@@ -59,6 +58,12 @@
 
   const getRegister = systemJSPrototype.getRegister;
   systemJSPrototype.getRegister = function () {
-    return firstNamedDefine || getRegister.call(this);
+    // Calling getRegister() because other extras need to know it was called so they can perform side effects
+    const register = getRegister.call(this);
+
+    const _firstNamedDefine = firstNamedDefine;
+    firstNamedDefine = null;
+
+    return _firstNamedDefine || register;
   }
 })(typeof self !== 'undefined' ? self : global);


### PR DESCRIPTION
See #2111. Also see https://github.com/systemjs/systemjs/pull/2105#discussion_r367777343, where our `setTimeout`'s were listed as an item we needed to address.

The bug in #2111 related to race conditions of clearing out the `firstNamedDefine` due to our usage of setTimeout. We really just want it to clear out once the named define has been used once, which is what this pull request changes about the amd and named-register extras.