### PR TITLE
Fix problem with named register modules. Resolves #2115.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -63,6 +63,12 @@
     }];
   }
 
+  const _import = systemPrototype.import;
+  systemPrototype.import = function() {
+    firstNamedDefine = null;
+    return _import.apply(this, arguments);
+  };
+
   // hook System.register to know the last declaration binding
   let lastRegisterDeclare;
   const systemRegister = systemPrototype.register;

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -19,13 +19,15 @@
 
   let firstNamedDefine;
 
-  function clearFirstNamedDefine () {
-    firstNamedDefine = null;
-  }
-
   function setRegisterRegistry(systemInstance) {
     systemInstance.registerRegistry = Object.create(null);
   }
+
+  const _import = systemJSPrototype.import;
+  systemJSPrototype.import = function() {
+    firstNamedDefine = null;
+    return _import.apply(this, arguments);
+  };
 
   const register = systemJSPrototype.register;
   systemJSPrototype.register = function (name, deps, declare) {

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -77,4 +77,15 @@ suite('Named System.register', function() {
       });
     });
   });
+
+  // https://github.com/systemjs/systemjs/issues/2115
+  test('loading a module after manual named register should return the loaded module', function () {
+    define('a-named-thing', [], function () {
+      return "named thing right before import";
+    });
+
+    return System.import('fixtures/amd-named-thing-as-dep.js').then(function (m) {
+      assert.equal(m.default, 'The module depending on the named thing');
+    });
+  });
 });

--- a/test/fixtures/browser/amd-named-thing-as-dep.js
+++ b/test/fixtures/browser/amd-named-thing-as-dep.js
@@ -1,0 +1,3 @@
+define(['a-named-thing'], function(namedThing) {
+  return 'The module depending on the named thing';
+});


### PR DESCRIPTION
See #2115. This was caused by removing the setTimeouts in https://github.com/systemjs/systemjs/pull/2114. We are now resetting the firstNamedDefine in two situations:

1) getRegister is called
2) System.import() is called.