### PR TITLE
Fixing more named register race conditions.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -155,6 +155,9 @@
   function addToRegisterRegistry(name, define) {
     if (!firstNamedDefine) {
       firstNamedDefine = define;
+      setTimeout(function () {
+        firstNamedDefine = null;
+      });
     }
 
     // We must call System.getRegister() here to give other extras, such as the named-exports extra,

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -63,12 +63,6 @@
     }];
   }
 
-  const _import = systemPrototype.import;
-  systemPrototype.import = function() {
-    firstNamedDefine = null;
-    return _import.apply(this, arguments);
-  };
-
   // hook System.register to know the last declaration binding
   let lastRegisterDeclare;
   const systemRegister = systemPrototype.register;

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -23,12 +23,6 @@
     systemInstance.registerRegistry = Object.create(null);
   }
 
-  const _import = systemJSPrototype.import;
-  systemJSPrototype.import = function() {
-    firstNamedDefine = null;
-    return _import.apply(this, arguments);
-  };
-
   const register = systemJSPrototype.register;
   systemJSPrototype.register = function (name, deps, declare) {
     if (typeof name !== 'string')

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -37,6 +37,9 @@
     this.registerRegistry[name] = define;
     if (!firstNamedDefine) {
       firstNamedDefine = define;
+      setTimeout(function () {
+        firstNamedDefine = null;
+      });
     }
     return register.apply(this, arguments);
   };

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -108,4 +108,27 @@ suite('Named System.register', function() {
       assert.equal(m.hello, 'there');
     });
   });
+
+  test('named define() called by code outside of SystemJS modules during import', function () {
+    const importPromise = System.import('fixtures/anonymous-define.js');
+
+    define('outside-systemjs', {thing: 'wrong'});
+
+    return importPromise.then(function (m) {
+      assert.equal(m.default.thing, 'correct');
+    });
+  });
+
+  test('named System.register() called by code outside of SystemJS modules during import', function () {
+    const importPromise = System.import('fixtures/anonymous-register.js');
+
+    System.register('named-register-outside-systemjs', [], function (_export) {
+      _export('thing', 'wrong');
+      return {};
+    });
+
+    return importPromise.then(function (m) {
+      assert.equal(m.thing, 'correct');
+    });
+  });
 });

--- a/test/fixtures/browser/anonymous-define.js
+++ b/test/fixtures/browser/anonymous-define.js
@@ -1,0 +1,1 @@
+define({thing: 'correct'});

--- a/test/fixtures/browser/anonymous-register.js
+++ b/test/fixtures/browser/anonymous-register.js
@@ -1,0 +1,4 @@
+System.register([], function (_export) {
+  _export('thing', 'correct');
+  return {};
+});

--- a/test/server.js
+++ b/test/server.js
@@ -5,7 +5,7 @@ const { once } = require('events');
 const { pathToFileURL, fileURLToPath } = require('url');
 const opn = require('opn');
 
-const port = 8085;
+const port = 8080;
 
 const systemJSURL = pathToFileURL(path.resolve(__dirname, '..') + '/');
 

--- a/test/server.js
+++ b/test/server.js
@@ -5,7 +5,7 @@ const { once } = require('events');
 const { pathToFileURL, fileURLToPath } = require('url');
 const opn = require('opn');
 
-const port = 8080;
+const port = 8085;
 
 const systemJSURL = pathToFileURL(path.resolve(__dirname, '..') + '/');
 


### PR DESCRIPTION
Unfortunately, @frehner and @TheMcMurder found some more race conditions that I overlooked in #2116.

Without the setTimeout, unexpected named calls to `define()` or `System.register()` while waiting for a `System.import()` to finish results in the wrong module being returned from getRegister(). If the calls to `define()` are a result of a `System.import()`, there is no problem. However, if the calls are not because of a `System.import()`, there is a problem.

I'm surprised I didn't think of this fairly obvious use case, and also that our tests didn't catch it. I've added two more tests that catch it now. All previous tests continue to pass with this change.