### PR TITLE
WIP: Refactoring named define.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "footprint:sjs": "terser dist/s.js -c passes=2 -m | gzip -9f | wc -c",
     "test": "mocha -b -r esm test/import-map.js test/system-core.js test/url-resolution.js && npm run test-browser",
     "test-browser": "node test/server.js",
+    "test-browser-watch": "WATCH_MODE=true node test/server.js",
     "prepublish": "npm run build"
   },
   "collective": {

--- a/test/fixtures/browser/named-amd.js
+++ b/test/fixtures/browser/named-amd.js
@@ -1,7 +1,7 @@
-define('c', ['exports', 'd'], function (exports, b) {
-  exports.a = b.b;
-});
-
 define('d', [], function () {
   return { b: 'b' };
+});
+
+define('c', ['exports', 'd'], function (exports, b) {
+  exports.a = b.b;
 });

--- a/test/fixtures/browser/named-bundle.js
+++ b/test/fixtures/browser/named-bundle.js
@@ -1,3 +1,13 @@
+System.register('b', [], function (exports) {
+  return {
+    execute: function () {
+      exports({
+        b: 'b'
+      });
+    }
+  };
+});
+
 System.register('a', ['b'], function (exports) {
   var b;
   return {
@@ -7,16 +17,6 @@ System.register('a', ['b'], function (exports) {
     execute: function () {
       exports({
         a: b
-      });
-    }
-  };
-});
-
-System.register('b', [], function (exports) {
-  return {
-    execute: function () {
-      exports({
-        b: 'b'
       });
     }
   };

--- a/test/server.js
+++ b/test/server.js
@@ -18,9 +18,13 @@ const mimes = {
   '.wasm': 'application/wasm'
 };
 
+const shouldExit = process.env.WATCH_MODE !== 'true'
+
 let failTimeout, browserTimeout;
 
 function setBrowserTimeout () {
+  if (!shouldExit)
+    return;
   if (browserTimeout)
     clearTimeout(browserTimeout);
   browserTimeout = setTimeout(() => {
@@ -35,12 +39,16 @@ http.createServer(async function (req, res) {
   setBrowserTimeout();
   if (req.url === '/done') {
     console.log('Tests completed successfully.');
-    process.exit();
+    if (shouldExit) {
+      process.exit();
+    }
     return;
   }
   else if (req.url === '/error') {
     console.log('\033[31mTest failures found.\033[0m');
-    failTimeout = setTimeout(() => process.exit(1), 30000);
+    if (shouldExit) {
+      failTimeout = setTimeout(() => process.exit(1), 30000);
+    }
   }
   else if (failTimeout) {
     clearTimeout(failTimeout);


### PR DESCRIPTION
See related https://github.com/systemjs/systemjs/issues/2138 and https://github.com/systemjs/systemjs/issues/2139.

I think the root cause of many of our named register woes is that we're trying to return the **first** register within the file being loaded instead, of the most recent register overall.

With the changes here, all tests pass except [this one](https://github.com/systemjs/systemjs/blob/55902716abffc791c15e4a2ef033876c280ae411/test/browser/named-register.js#L122). I am exploring options to make that one pass, too.

@guybedford I'd like to hear your thoughts on these changes. They are a breaking change in that when a single file calls named register multiple times, this code now returns the last register instead of the first within the file. However, it does solve our race condition problems.