### PR TITLE
Fix for AMD named register race conditions.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -151,7 +151,7 @@
   function addToRegisterRegistry(name, define) {
     if (!firstNamedDefine) {
       firstNamedDefine = define;
-      setTimeout(function () {
+      Promise.resolve().then(function () {
         firstNamedDefine = null;
       });
     }

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -17,7 +17,7 @@
   SystemJS.prototype = systemJSPrototype;
   System.constructor = SystemJS;
 
-  let firstNamedDefine;
+  let firstNamedDefine, tmpDefine;
 
   function setRegisterRegistry(systemInstance) {
     systemInstance.registerRegistry = Object.create(null);
@@ -28,10 +28,12 @@
     if (typeof name !== 'string')
       return register.apply(this, arguments);
     const define = [deps, declare];
-    this.registerRegistry[name] = define;
+    tmpDefine = define;
+    this.registerRegistry[name] = System.getRegister();
+    tmpDefine = null;
     if (!firstNamedDefine) {
       firstNamedDefine = define;
-      setTimeout(function () {
+      Promise.resolve().then(function () {
         firstNamedDefine = null;
       });
     }
@@ -64,6 +66,9 @@
 
   const getRegister = systemJSPrototype.getRegister;
   systemJSPrototype.getRegister = function () {
+    if (tmpDefine) {
+      return tmpDefine;
+    }
     // Calling getRegister() because other extras need to know it was called so they can perform side effects
     const register = getRegister.call(this);
 

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -17,7 +17,7 @@
   SystemJS.prototype = systemJSPrototype;
   System.constructor = SystemJS;
 
-  let firstNamedDefine, tmpDefine;
+  let firstNamedDefine;
 
   function setRegisterRegistry(systemInstance) {
     systemInstance.registerRegistry = Object.create(null);
@@ -28,9 +28,7 @@
     if (typeof name !== 'string')
       return register.apply(this, arguments);
     const define = [deps, declare];
-    tmpDefine = define;
-    this.registerRegistry[name] = System.getRegister();
-    tmpDefine = null;
+    this.registerRegistry[name] = define;
     if (!firstNamedDefine) {
       firstNamedDefine = define;
       Promise.resolve().then(function () {
@@ -66,9 +64,6 @@
 
   const getRegister = systemJSPrototype.getRegister;
   systemJSPrototype.getRegister = function () {
-    if (tmpDefine) {
-      return tmpDefine;
-    }
     // Calling getRegister() because other extras need to know it was called so they can perform side effects
     const register = getRegister.call(this);
 


### PR DESCRIPTION
See related https://github.com/systemjs/systemjs/issues/2139 and #2138. Note that this is an alternative implementation to #2140 -- this one preserves the `firstNamedDefine` behavior.

@freezesoul @shrinktofit can you confirm is this fixes the problems that you reported? If not, I think we'll go with #2140 instead.