### PR TITLE
Adding test-browser-watch script, and fixing nodejs cjs/esm interop warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "footprint:systemjs": "terser dist/system.js -c passes=2 -m | gzip -9f | wc -c",
     "footprint:sjs": "terser dist/s.js -c passes=2 -m | gzip -9f | wc -c",
     "test": "mocha -b -r esm test/import-map.js test/system-core.js test/url-resolution.js && npm run test-browser",
-    "test-browser": "node test/server.js",
+    "test-browser": "node test/server.cjs",
+    "test-browser-watch": "WATCH_MODE=true node test/server.cjs",
     "prepublish": "npm run build"
   },
   "collective": {

--- a/test/server.cjs
+++ b/test/server.cjs
@@ -18,9 +18,13 @@ const mimes = {
   '.wasm': 'application/wasm'
 };
 
+const shouldExit = process.env.WATCH_MODE !== 'true'
+
 let failTimeout, browserTimeout;
 
 function setBrowserTimeout () {
+  if (!shouldExit)
+    return;
   if (browserTimeout)
     clearTimeout(browserTimeout);
   browserTimeout = setTimeout(() => {
@@ -35,12 +39,16 @@ http.createServer(async function (req, res) {
   setBrowserTimeout();
   if (req.url === '/done') {
     console.log('Tests completed successfully.');
-    process.exit();
+    if (shouldExit) {
+      process.exit();
+    }
     return;
   }
   else if (req.url === '/error') {
     console.log('\033[31mTest failures found.\033[0m');
-    failTimeout = setTimeout(() => process.exit(1), 30000);
+    if (shouldExit) {
+      failTimeout = setTimeout(() => process.exit(1), 30000);
+    }
   }
   else if (failTimeout) {
     clearTimeout(failTimeout);


### PR DESCRIPTION
This is handy for when you can't debug the test in 10 seconds, which usually causes the server to shut down. Also, renaming the file to `.cjs` fixed a warning - systemjs has `type` set to module so it has to use `.cjs` to load up commonjs modules