### PR TITLE
Add file size impact workflow for pull requests.

### DIFF
--- a/.github/workflows/size-impact.yml
+++ b/.github/workflows/size-impact.yml
@@ -1,0 +1,49 @@
+name: size-impact
+
+on: pull_request
+
+jobs:
+  size-impact:
+    if: github.event.pull_request.base.repository == github.event.pull_request.head.repository
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [13.12.0]
+    runs-on: ${{ matrix.os }}
+    name: size impact
+    env:
+      CI: true
+    steps:
+      - name: Setup git
+        env:
+          GITHUB_REPOSITORY_URL: ${{ github.repositoryUrl }}
+        run: |
+          git init
+          git remote add origin $GITHUB_REPOSITORY_URL
+      - name: Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Git checkout base
+        run: |
+          git fetch --no-tags --prune --depth=1 origin $GITHUB_BASE_REF
+          git checkout origin/$GITHUB_BASE_REF
+          git log -1
+      - name: Generate snapshot for base
+        run: |
+          npm install
+          npm run build
+          node ./.github/workflows/size-impact/generate-size-snapshot.js ../snapshot.base.json || echo "{}" > ../snapshot.base.json
+      - name: Git merge head
+        run: |
+          git fetch --no-tags --prune origin $GITHUB_REF
+          git merge FETCH_HEAD
+      - name: Generate snapshot after merge
+        run: |
+          npm install
+          npm run build
+          node ./.github/workflows/size-impact/generate-size-snapshot.js ../snapshot.head.json
+      - name: Report size impact
+        run: node ./.github/workflows/size-impact/report-size-impact.js ../snapshot.base.json ../snapshot.head.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size-impact/generate-size-snapshot.js
+++ b/.github/workflows/size-impact/generate-size-snapshot.js
@@ -1,0 +1,12 @@
+import { generateSnapshotFile } from "@jsenv/github-pull-request-filesize-impact";
+
+generateSnapshotFile({
+  projectDirectoryUrl: new URL("../../../", import.meta.url),
+  snapshotFileRelativeUrl: process.argv[2],
+  directorySizeTrackingConfig: {
+    dist: {
+      "**/*": true,
+      "**/*.map": false,
+    },
+  },
+});

--- a/.github/workflows/size-impact/report-size-impact.js
+++ b/.github/workflows/size-impact/report-size-impact.js
@@ -1,0 +1,8 @@
+import { reportSizeImpactIntoGithubPullRequest } from "@jsenv/github-pull-request-filesize-impact";
+
+reportSizeImpactIntoGithubPullRequest({
+  projectDirectoryUrl: new URL("../../../", import.meta.url),
+  baseSnapshotFileRelativeUrl: process.argv[2],
+  headSnapshotFileRelativeUrl: process.argv[3],
+  generatedByLink: false,
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "devDependencies": {
     "@rollup/plugin-replace": "^2.3.1",
+    "@jsenv/github-pull-request-filesize-impact": "^2.6.0",
     "bluebird": "^3.7.2",
     "construct-style-sheets-polyfill": "^2.3.5",
     "cross-env": "^7.0.2",


### PR DESCRIPTION
### Presentation

Hello this is a follow up of https://github.com/systemjs/systemjs/issues/2153.

This pull requests adds a GitHub workflow. This workflow is runned every time a pull request is opened or updated. It computes a pull request impact on `dist/*` file sizes and comment the pull request. The workflow uses https://github.com/jsenv/jsenv-github-pull-request-filesize-impact under the hood.

Unfortunately a pull request opened from a fork is not allowed to post comment on the main repository pull request. The workflow is [disabled](https://github.com/systemjs/systemjs/blob/0413e6bf8722881fbeb14ce8a50972b62a78727c/.github/workflows/size-impact.yml#L7) for forks until GitHub finds a solution to [the issue](https://github.community/t5/GitHub-Actions/Token-permissions-for-forks-once-again/td-p/33839). 

### Example

I have prepared an example inside my fork. There is a pull request with a basic change to give you an idea of the result.

#### Screenshot of the diff

![image](https://user-images.githubusercontent.com/443639/78498684-0565d100-774c-11ea-9c80-9bd858a61a88.png)

#### Screenshot of the comment generated in the pull request

![image](https://user-images.githubusercontent.com/443639/78498848-2aa70f00-774d-11ea-8bcf-916e8a80d0ff.png)

These screenshot where generated from https://github.com/dmail-fork/systemjs/pull/2