### PR TITLE
Running tests and build automatically in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ git:
   depth: 1
 language: node_js
 node_js:
-  - '10'
-
-before_install:
-  - npm install
+  - node
+env:
+  global:
+    - MOZ_HEADLESS=1
+addons:
+  firefox: latest
 script:
   - npm run build
-  - npm run test
+  - npm test


### PR DESCRIPTION
In order for travis ci to be enabled, permissions must be granted. I think that that can be done at https://github.com/organizations/systemjs/settings/oauth_application_policy. I don't have permissions for it. Once that is done, the builds should be publicly visible at https://travis-ci.com/systemjs/systemjs

This uses a headless firefox to run the tests.