### PR TITLE
 Fixing NodeJS build and tests. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SystemJS
 
-[![Build Status][travis-image]][travis-url]
+[![Build Status](https://travis-ci.com/systemjs/systemjs.svg?branch=master)](https://travis-ci.com/systemjs/systemjs)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/systemjs/systemjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Backers on Open Collective](https://opencollective.com/systemjs/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/systemjs/sponsors/badge.svg)](#sponsors)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build:node": "node --experimental-modules build-node.js",
     "build:browser:prod": "rollup -c",
     "build:browser:dev": "rollup -c --environment dev",
-    "footprint": "npm run footprint:systemjs && npm run footprint:sjs",
+    "footprint": "concurrently -n w: 'npm:footprint:*'",
     "footprint:systemjs": "cat dist/system.min.js | gzip -9f | wc -c",
     "footprint:sjs": "cat dist/s.min.js | gzip -9f | wc -c",
     "test": "concurrently -n w: 'npm:test:*'",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cross-env": "^7.0.2",
     "make-fetch-happen": "^8.0.4",
     "mocha": "^7.1.1",
-    "opn": "^6.0.0",
+    "open": "^7.0.3",
     "rimraf": "^3.0.2",
     "rollup": "^2.2.0",
     "rollup-plugin-terser": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "footprint:systemjs": "cat dist/system.min.js | gzip -9f | wc -c",
     "footprint:sjs": "cat dist/s.min.js | gzip -9f | wc -c",
     "test": "concurrently -n w: 'npm:test:*'",
-    "test:internals": "NODE_OPTIONS=--experimental-modules mocha -b --file test/mocha-setup.js test/import-map.js test/system-core.js test/url-resolution.js",
-    "test:node": "NODE_OPTIONS=--experimental-modules mocha -b --file test/mocha-setup.js test/system-node.js",
+    "test:internals": "cross-env NODE_OPTIONS=--experimental-modules mocha -b --file test/mocha-setup.js test/import-map.js test/system-core.js test/url-resolution.js",
+    "test:node": "cross-env NODE_OPTIONS=--experimental-modules mocha -b --file test/mocha-setup.js test/system-node.js",
     "test:browser": "node test/server.cjs",
     "test-browser-watch": "cross-env WATCH_MODE=true node test/server.cjs",
     "prepublish": "npm run build"

--- a/src/features/import-map.js
+++ b/src/features/import-map.js
@@ -14,6 +14,8 @@ import { BASE_URL, baseUrl, resolveAndComposeImportMap, resolveImportMap, resolv
 import { systemJSPrototype } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
 
+export { IMPORT_MAP };
+
 var IMPORT_MAP = hasSymbol ? Symbol() : '#';
 var IMPORT_MAP_PROMISE = hasSymbol ? Symbol() : '$';
 

--- a/src/system-node.js
+++ b/src/system-node.js
@@ -1,11 +1,10 @@
-import './system-node-baseurl.js';
-
+import { REGISTRY } from './system-core.js';
 import { IMPORT_MAP } from './features/import-map.js';
 import './features/registry.js';
 import './extras/global.js';
 import './extras/module-types.js';
 import './features/node-fetch.js';
-import { BASE_URL } from './common.js';
+import { BASE_URL, baseUrl, resolveAndComposeImportMap } from './common.js';
 
 export const System = global.System;
 
@@ -22,6 +21,6 @@ export function setBaseUrl(loader, url) {
 }
 
 function ensureValidSystemLoader (loader) {
-  if (!loader[IMPORT_MAP])
+  if (!loader[REGISTRY])
     throw new Error('A valid SystemJS instance must be provided');
 }

--- a/test/server.cjs
+++ b/test/server.cjs
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const { once } = require('events');
 const { pathToFileURL, fileURLToPath } = require('url');
-const opn = require('opn');
+const open = require('open');
 
 const port = 8080;
 
@@ -96,4 +96,5 @@ http.createServer(async function (req, res) {
 }).listen(port);
 
 console.log(`Test server listening on http://localhost:${port}\n`);
-opn(`http://localhost:${port}/test/test.html`);
+const openOptions = process.env.CI ? { app: ['firefox'] } : {};
+open(`http://localhost:${port}/test/test.html`, openOptions);

--- a/test/system-node.js
+++ b/test/system-node.js
@@ -31,7 +31,6 @@ describe('NodeJS version of SystemJS', () => {
     });
 
     it('allows the base URL to be set to a valid full URL', () => {
-      applyImportMap(System, {imports: {"rxjs": "https://unpkg.com/@esm-bundle/rxjs@6.5.4-fix.0/system/rxjs.min.js"}});
       setBaseUrl(System, 'http://localhost:9650/some-prefix/');
       assert.equal(System.resolve('./foo.js'), 'http://localhost:9650/some-prefix/foo.js');
     });

--- a/test/system-node.js
+++ b/test/system-node.js
@@ -31,7 +31,8 @@ describe('NodeJS version of SystemJS', () => {
     });
 
     it('allows the base URL to be set to a valid full URL', () => {
-      setBaseUrl('http://localhost:9650/some-prefix/');
+      applyImportMap(System, {imports: {"rxjs": "https://unpkg.com/@esm-bundle/rxjs@6.5.4-fix.0/system/rxjs.min.js"}});
+      setBaseUrl(System, 'http://localhost:9650/some-prefix/');
       assert.equal(System.resolve('./foo.js'), 'http://localhost:9650/some-prefix/foo.js');
     });
   });


### PR DESCRIPTION
- The link to travis in the readme was pointing to travis-ci.org instead of travis-ci.com
- NodeJS build and tests had some bugs
- `opn` was deprecated and renamed to `open`. See https://www.npmjs.com/package/opn
- I think `open` was not working in the CI environment, likely due to no default browser being set. I'm trying out forcibly opening firefox in CI environments.
- Making `npm run footprint` slightly faster, with concurrently package
- Setting env vars for `npm test` with cross-env, so that it works in windows