### PR TITLE
Upgrade pull request size impact to 3.0.

### DIFF
--- a/.github/workflows/size-impact.yml
+++ b/.github/workflows/size-impact.yml
@@ -4,7 +4,9 @@ on: pull_request
 
 jobs:
   size-impact:
-    if: github.event.pull_request.base.repository == github.event.pull_request.head.repository
+    # disable workflow for forks because of
+    # https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token
+    if: github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/size-impact/generate-size-snapshot.js
+++ b/.github/workflows/size-impact/generate-size-snapshot.js
@@ -1,12 +1,22 @@
-import { generateSnapshotFile } from "@jsenv/github-pull-request-filesize-impact";
+import {
+  generateSnapshotFile,
+  none,
+  gzip,
+  brotli,
+} from "@jsenv/github-pull-request-filesize-impact";
 
 generateSnapshotFile({
   projectDirectoryUrl: new URL("../../../", import.meta.url),
   snapshotFileRelativeUrl: process.argv[2],
-  directorySizeTrackingConfig: {
-    dist: {
-      "**/*": true,
-      "**/*.map": false,
+  trackingConfig: {
+    core: {
+      "./dist/*": true,
+      "./dist/*.map": false,
+    },
+    extras: {
+      "./dist/extras/**/*.js": true,
+      "./dist/extras/**/*.map": false,
     },
   },
+  transformations: { none, gzip, brotli },
 });

--- a/.github/workflows/size-impact/report-size-impact.js
+++ b/.github/workflows/size-impact/report-size-impact.js
@@ -4,5 +4,6 @@ reportSizeImpactIntoGithubPullRequest({
   projectDirectoryUrl: new URL("../../../", import.meta.url),
   baseSnapshotFileRelativeUrl: process.argv[2],
   headSnapshotFileRelativeUrl: process.argv[3],
-  generatedByLink: false,
+  commentSections: { fileByFileImpact: true },
+  generatedByLink: true,
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@jsenv/github-pull-request-filesize-impact": "^2.6.0",
+    "@jsenv/github-pull-request-filesize-impact": "^3.0.2",
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",


### PR DESCRIPTION
Hey I made an update to the package commenting pull request with its impact on filesizes. You can now track gzip and brotli sizes 🎉 . 

Just like the previous one I did a basic change

![image](https://user-images.githubusercontent.com/443639/78913043-b17b2500-7a88-11ea-9fdf-c6b9d8a48985.png)

And you can see the corresponding comment generated.

![image](https://user-images.githubusercontent.com/443639/78913112-cc4d9980-7a88-11ea-86a9-9135d23dbd99.png)

And the comment expanded screenshot.

![image](https://user-images.githubusercontent.com/443639/78913151-dc657900-7a88-11ea-9198-6da6eb1f9482.png)

As you can see, I took the liberty to configure two groups called `core` and `extras`. It's configured in [.github/workflows/size-impact/generate-size-snapshot.js](https://github.com/dmail-fork/systemjs/blob/aa54e413181d1ade9fb8e130120f2c39190ba007/.github/workflows/size-impact/generate-size-snapshot.js#L13).
I thought it would make sense to have them splitted for systemjs.

And of course the gzip and brotli size once expanded.

Good for you ?

