### PR TITLE
Fixing tests in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,12 @@
     "rollup": "^2.2.0",
     "rollup-plugin-terser": "^5.3.0",
     "source-map-support": "^0.5.16",
+    "symbol-es6": "^0.1.2",
     "terser": "^4.6.7",
     "whatwg-fetch": "^3.0.0"
   },
   "scripts": {
-    "build": "rimraf dist && concurrently -n w: 'yarn:build:*'",
+    "build": "rimraf dist && concurrently -n w: 'npm:build:*'",
     "build:node": "node --experimental-modules build-node.js",
     "build:browser": "rollup -c",
     "build-browser-dev": "rollup -c --environment dev",

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -85,6 +85,6 @@
   function shouldSkipProperty(p) {
     return !global.hasOwnProperty(p)
       || !isNaN(p) && p < global.length
-      || isIE11 && global[p] && global[p].parent === window;
+      || isIE11 && global[p] && typeof window !== 'undefined' && global[p].parent === window;
   }
 })(typeof self !== 'undefined' ? self : global);

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -159,17 +159,19 @@ suite('SystemJS Standard Tests', function() {
     });
   });
 
-  test('should load a css module', async function () {
-    const m = await System.import('fixturesbase/css-modules/a.css');
-    assert.ok(m);
-    assert.ok(m.default instanceof CSSStyleSheet);
-    document.adoptedStyleSheets = [...document.adoptedStyleSheets, m.default];
+  test('should load a css module', function () {
+    return System.import('fixturesbase/css-modules/a.css').then(function (m) {
+      assert.ok(m);
+      assert.ok(isCSSStyleSheet(m.default));
+      document.adoptedStyleSheets = document.adoptedStyleSheets.concat(m.default);
+    });
   });
 
-  test('should support application/javascript css module override', async function () {
-    const m = await System.import('fixturesbase/css-modules/javascript.css');
-    assert.ok(m);
-    assert.ok(m.css, 'module');
+  test('should support application/javascript css module override', function () {
+    return System.import('fixturesbase/css-modules/javascript.css').then(function (m) {
+      assert.ok(m);
+      assert.ok(m.css, 'module');
+    });
   });
 
   test('should throw when trying to load an HTML module', function () {
@@ -208,14 +210,24 @@ suite('SystemJS Standard Tests', function() {
   test('should not get confused by filenames in url hash when resolving module type', function () {
     return System.import('fixturesbase/css-modules/hash.css?foo=bar.html').then(function (m) {
       assert.ok(m);
-      assert.ok(m.default instanceof CSSStyleSheet);
+      assert.ok(isCSSStyleSheet(m.default));
     });
   });
 
   test('should not get confused by filenames in search params hash when resolving module type', function () {
     return System.import('fixturesbase/css-modules/search-param.css?param=foo.html').then(function (m) {
       assert.ok(m);
-      assert.ok(m.default instanceof CSSStyleSheet);
+      assert.ok(isCSSStyleSheet(m.default));
     });
   });
+
+  var isIE11 = typeof navigator !== 'undefined' && navigator.userAgent.indexOf('Trident') !== -1;
+
+  function isCSSStyleSheet(obj) {
+    if (isIE11) {
+      return obj.cssRules;
+    } else {
+      return obj instanceof CSSStyleSheet;
+    }
+  }
 });

--- a/test/browser/transform.js
+++ b/test/browser/transform.js
@@ -6,6 +6,8 @@ suite('Transform Loader', function() {
     return source;
   };
 
+  const supportsWebAssembly = typeof WebAssembly !== 'undefined' && typeof process === 'undefined';
+
   suite('SystemJS standard tests', function () {
 
     test('String encoding', function () {
@@ -67,7 +69,7 @@ suite('Transform Loader', function() {
       });
     });
 
-    if (typeof WebAssembly !== 'undefined' && typeof process === 'undefined')
+    if (supportsWebAssembly)
     test('Loading WASM', function () {
       return System.import('fixtures/wasm/example.wasm')
       .then(function (m) {
@@ -76,7 +78,8 @@ suite('Transform Loader', function() {
     });
 
     test('Verification', function () {
-      assert.equal(translateCnt, 8);
+      const expected = supportsWebAssembly ? 8 : 7;
+      assert.equal(translateCnt, expected);
     });
   });
 });

--- a/test/browser/worker.js
+++ b/test/browser/worker.js
@@ -1,3 +1,4 @@
+importScripts('../../node_modules/bluebird/js/browser/bluebird.core.js');
 importScripts('../../dist/system.js');
 
 System.import('../fixtures/register-modules/es6-withdep.js').then(function(m) {

--- a/test/system-node.js
+++ b/test/system-node.js
@@ -15,7 +15,7 @@ describe('NodeJS version of SystemJS', () => {
 
   describe('resolve', () => {
     it('provides a default base url if one is not specified', () => {
-      assert.equal(System.resolve('./foo.js'), pathToFileURL(process.cwd()) + path.sep + 'foo.js');
+      assert.equal(System.resolve('./foo.js'), pathToFileURL(process.cwd()).href + '/foo.js');
     });
 
     it('works if a full url is provided', () => {

--- a/test/test.html
+++ b/test/test.html
@@ -6,9 +6,17 @@
 	</script>
 	<script>
 		if (typeof fetch === 'undefined')
-			document.write('<script src="../node_modules/whatwg-fetch/fetch.js"><\/script>');
+			document.write('<script src="../node_modules/whatwg-fetch/dist/fetch.umd.js"><\/script>');
 	</script>
-	<script defer src="../node_modules/construct-style-sheets-polyfill/dist/adoptedStyleSheets.js"></script>
+	<script>
+		// SystemJS doesn't require a Symbol polyfill, but construct-style-sheets-polyfill does
+		if (typeof Symbol === 'undefined')
+			document.write('<script src="../node_modules/symbol-es6/dist/symbol-es6.min.js"><\/script>');
+	</script>
+	<script>
+		if (typeof document.adoptedStyleSheets === 'undefined')
+			document.write('<script src="../node_modules/construct-style-sheets-polyfill/dist/adoptedStyleSheets.js"><\/script>');
+	</script>
 	<script>
 		// TODO IE11 URL polyfill testing
 		// if (typeof URL === 'undefined')


### PR DESCRIPTION
- construct-style-sheets-polyfill requires Symbol polyfill, so I added that to the tests.
- `window` is undefined inside of Web Workers in IE11, so I did a check for that
- `obj instanceof CSSStyleSheet` doesn't work in IE11. Not sure why - likely due to the polyfill
- Fix standard tests verification that assumed web assembly test had executed
- Add promise polyfill to web worker in IE11 tests
- Fix issue where path.sep was being used instead of `/` in a file url.
- Only load the construct-style-sheets-polyfill in tests when needed

I verified that all tests pass in Windows and IE11 now. Am checking Safari and Edge now, too. I have been running the tests against both system.js and system.min.js to test the new terser config, and everything appears to be working