### PR TITLE
Fix error code mixup

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -26,7 +26,7 @@ Note that this error also can occur for external import maps (those with `src=""
 
 ## 2
 
-## Module did not instantiate
+### Module did not instantiate
 
 SystemJS Error #2 occurs when a module fails to instantiate.
 
@@ -111,11 +111,7 @@ SystemJS checks the HTTP [Response](https://developer.mozilla.org/en-US/docs/Web
 
 To diagnose the problem, identify which module failed to load. Then check the browser console and network tab of your devtools to find the HTTP status. In order for the module to successfully load, the status needs to be >= 200 and < 300.
 
-# SystemJS Warnings
-
-This sections lists the SystemJS warnings that you may encounter.
-
-## W1
+## 8
 
 ### Unable to resolve bare specifier
 
@@ -166,6 +162,14 @@ To fix this warning, you may either use [import maps](/docs/import-maps.md) or [
   })()
 </script>
 ```
+
+# SystemJS Warnings
+
+This sections lists the SystemJS warnings that you may encounter.
+
+## W1
+
+SystemJS Warning #1 occurs when there is an error resolving a bare specifier on the right hand side of an import map. See [Error #8](#8) for more detail on fixing bare specifier errors.
 
 ## W2
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -169,7 +169,11 @@ This sections lists the SystemJS warnings that you may encounter.
 
 ## W1
 
+### Unable to resolve bare specifier
+
 SystemJS Warning #1 occurs when there is an error resolving a bare specifier on the right hand side of an import map. See [Error #8](#8) for more detail on fixing bare specifier errors.
+
+Import maps are fully parsed and resolved at initialization time, with validation warnings output in line with the import maps specification. Any resolution errors in the import map are displayed as validation warnings and those import map entries are then ignored in the resolution process.
 
 ## W2
 

--- a/src/extras/transform.js
+++ b/src/extras/transform.js
@@ -15,7 +15,7 @@ import { errMsg } from '../err-msg.js';
     return fetch(url, { credentials: 'same-origin' })
     .then(function (res) {
       if (!res.ok)
-        throw Error(errMsg(9, process.env.SYSTEM_PRODUCTION ? [res.status, res.statusText, parent].join(', ') : 'Fetch error: ' + res.status + ' ' + res.statusText + (parent ? ' loading from ' + parent : '')));
+        throw Error(errMsg(7, process.env.SYSTEM_PRODUCTION ? [res.status, res.statusText, parent].join(', ') : 'Fetch error: ' + res.status + ' ' + res.statusText + (parent ? ' loading from ' + parent : '')));
       return res.text();
     })
     .then(function (source) {

--- a/src/features/import-map.js
+++ b/src/features/import-map.js
@@ -55,7 +55,7 @@ systemJSPrototype.resolve = function (id, parentUrl) {
 };
 
 function throwUnresolved (id, parentUrl) {
-  throw Error(errMsg(2, process.env.SYSTEM_PRODUCTION ? [id, parentUrl].join(', ') : "Unable to resolve bare specifier '" + id + (parentUrl ? "' from " + parentUrl : "'")));
+  throw Error(errMsg(8, process.env.SYSTEM_PRODUCTION ? [id, parentUrl].join(', ') : "Unable to resolve bare specifier '" + id + (parentUrl ? "' from " + parentUrl : "'")));
 }
 
 function iterateDocumentImportMaps(cb, extraSelector) {


### PR DESCRIPTION
There is an error message that occurs both as an error and a warning (unable to resolve specifier). We consolidated them down into a single error, but then split them back up when we created a separate Warnings section in the docs. In doing so, I messed up the numbering of some of the errors / warnings. This PR fixes that.

Also, we consolidated error 7 and 9 in the documentation, but not in the source code. So this fixes that, too.