### PR TITLE
Fix bug in system-node where prepareImport overwrote import map.

### DIFF
--- a/src/features/import-map.js
+++ b/src/features/import-map.js
@@ -14,7 +14,7 @@ import { BASE_URL, baseUrl, resolveAndComposeImportMap, resolveImportMap, resolv
 import { systemJSPrototype } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
 
-export { IMPORT_MAP };
+export { IMPORT_MAP, IMPORT_MAP_PROMISE };
 
 var IMPORT_MAP = hasSymbol ? Symbol() : '#';
 var IMPORT_MAP_PROMISE = hasSymbol ? Symbol() : '$';

--- a/src/system-node.js
+++ b/src/system-node.js
@@ -1,5 +1,5 @@
-import { REGISTRY } from './system-core.js';
-import { IMPORT_MAP } from './features/import-map.js';
+import { REGISTRY, systemJSPrototype } from './system-core.js';
+import { IMPORT_MAP, IMPORT_MAP_PROMISE } from './features/import-map.js';
 import './features/registry.js';
 import './extras/global.js';
 import './extras/module-types.js';
@@ -8,9 +8,19 @@ import { BASE_URL, baseUrl, resolveAndComposeImportMap } from './common.js';
 
 export const System = global.System;
 
+const originalResolve = systemJSPrototype.resolve;
+systemJSPrototype.resolve = function () {
+  if (!this[IMPORT_MAP]) {
+    // Allow for basic URL resolution before applyImportMap is called
+    this[IMPORT_MAP] = { imports: {}, scopes: {} };
+  }
+  return originalResolve.apply(this, arguments);
+};
+
 export function applyImportMap(loader, newMap, mapBase) {
   ensureValidSystemLoader(loader);
   loader[IMPORT_MAP] = resolveAndComposeImportMap(newMap, mapBase || baseUrl, loader[IMPORT_MAP] || { imports: {}, scopes: {} });
+  loader[IMPORT_MAP_PROMISE] = Promise.resolve();
 }
 
 export { clearFetchCache } from './features/node-fetch.js';

--- a/test/system-node.js
+++ b/test/system-node.js
@@ -10,7 +10,6 @@ describe('NodeJS version of SystemJS', () => {
 
   beforeEach(() => {
     System = new globalSystem.constructor();
-    return System.prepareImport();
   });
 
   describe('resolve', () => {
@@ -44,7 +43,7 @@ describe('NodeJS version of SystemJS', () => {
       assert.ok(rxjs.Observable);
     });
 
-    it('can load a module from disk without setting base url', async () => {
+    it('can load a module from disk without setting base url, before prepareImport is called', async () => {
       applyImportMap(System, {imports: {"foo": 'file://' + path.join(process.cwd(), 'test/fixtures/register-modules/export.js')}});
       const foo = await System.import('foo');
       assert.equal(foo.p, 5);


### PR DESCRIPTION
This fixes two issues related to prepareImport in system-node.cjs:

1. Calling `applyImportMap()` before `prepareImport()` would result in the import map being discarded during prepareImport(). This is due to `IMPORT_MAP_PROMISE` not being set by applyImportMap, which resulted in import-maps.js setting the import map to an empty map. This bug was hidden by the tests because they were all calling prepareImport inside of a beforeEach. See related https://github.com/systemjs/systemjs/blob/e981b02bca26090a7236434fa4b17b7b26aca7dc/src/features/import-map.js#L30-L31.

2. System.resolve() throws an error in nodejs if you have not called prepareImport() or applyImportMap() first. This behavior makes sense in the browser due to the possibility of external import maps, but doesn't make sense in nodejs since there is no possibility of external import maps. This error is confusing to a user that wants to use system-node.cjs without using import maps. My fix was to hook `resolve` inside of system-node so that their is always an empty map on every loader instance before resolveImportMap is called.