### PR TITLE
Adding full dist directory to package.json exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "6.3.0",
   "main": "dist/system-node.cjs",
   "exports": {
-    "node": "./dist/system-node.cjs",
-    "default": "./dist/system.min.js"
+    ".": {
+      "node": "./dist/system-node.cjs",
+      "default": "./dist/system.min.js"
+    },
+    "./dist/": "./dist/"
   },
   "description": "Dynamic ES module loader",
   "repository": {


### PR DESCRIPTION
Without this, you can't use any of the extras in NodeJS.

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/extras/amd.js' is not defined by "exports" in /Users/joeldenning/code/isomorphic-root-config/node_modules/systemjs/package.json
```

I considered remapping so that the dist was not necessary in import paths. But I think that would be a breaking change since some people are already doing `import 'systemjs/dist/system.js'` (at least in webpack bundles) and have the dist in their code.