### PR TITLE
Make setters optional

### DIFF
--- a/src/system-core.js
+++ b/src/system-core.js
@@ -113,8 +113,10 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
         }
       }
       if (changed)
-        for (var i = 0; i < importerSetters.length; i++)
-          importerSetters[i](ns);
+        for (var i = 0; i < importerSetters.length; i++) {
+          var setter = importerSetters[i];
+          if (setter) setter(ns);
+        }
       return value;
     }
     var declared = registration[1](_export, registration[1].length === 2 ? {


### PR DESCRIPTION
When importing a file that doesn't have any dependency, it can be useful to adjust the System format to support `null` setter entries rather than needing to provide an empty `function () {}`.

See for example the RollupJS output here where the first setter is empty - http://rollupjs.org/repl/?version=2.10.9&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMCU3QiUyMGN1YmUlMjAlN0QlMjBmcm9tJTIwJy4lMkZtYXRocy5qcyclM0IlNUNuY3ViZSh4KSUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTJDJTdCJTIybmFtZSUyMiUzQSUyMm1hdGhzLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMHNxdWFyZSUyMGZyb20lMjAnLiUyRnNxdWFyZS5qcyclM0IlNUNuJTVDbmV4cG9ydCUyMCU3QmRlZmF1bHQlMjBhcyUyMHNxdWFyZSU3RCUyMGZyb20lMjAnLiUyRnNxdWFyZS5qcyclM0IlNUNuJTVDbmV4cG9ydCUyMGZ1bmN0aW9uJTIwY3ViZSUyMCh4JTIwKSUyMCU3QiU1Q24lNUN0cmV0dXJuJTIwc3F1YXJlKHgpJTIwKiUyMHglM0IlNUNuJTdEJTIyJTJDJTIyaXNFbnRyeSUyMiUzQXRydWUlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIyc3F1YXJlLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGRlZmF1bHQlMjBmdW5jdGlvbiUyMHNxdWFyZSUyMCglMjB4JTIwKSUyMCU3QiU1Q24lNUN0cmV0dXJuJTIweCUyMColMjB4JTNCJTVDbiU3RCUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMnN5c3RlbSUyMiUyQyUyMm5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmFtZCUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyJTIyJTdEJTJDJTIyZ2xvYmFscyUyMiUzQSU3QiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE