### PR TITLE
Add error message for missing content-type header

### DIFF
--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -26,6 +26,8 @@ import { errMsg } from '../err-msg.js';
         if (!res.ok)
           throw Error(errMsg(7, process.env.SYSTEM_PRODUCTION ? [res.status, res.statusText, url, parent].join(', ') : res.status + ' ' + res.statusText + ', loading ' + url + (parent ? ' from ' + parent : '')));
         var contentType = res.headers.get('content-type');
+        if (!contentType)
+          throw Error(errMsg(4, 'Missing header "Content-Type"'));
         if (contentType.match(/^(text|application)\/(x-)?javascript(;|$)/)) {
           return res.text().then(function (source) {
             (0, eval)(source);

--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -27,7 +27,7 @@ import { errMsg } from '../err-msg.js';
           throw Error(errMsg(7, process.env.SYSTEM_PRODUCTION ? [res.status, res.statusText, url, parent].join(', ') : res.status + ' ' + res.statusText + ', loading ' + url + (parent ? ' from ' + parent : '')));
         var contentType = res.headers.get('content-type');
         if (!contentType)
-          throw Error(errMsg(4, 'Missing header "Content-Type"'));
+          throw Error(errMsg(4, process.env.SYSTEM_PRODUCTION ? [url, parent] : 'Missing header "Content-Type", loading ' + url + (parent ? ' from ' + parent : '')));
         if (contentType.match(/^(text|application)\/(x-)?javascript(;|$)/)) {
           return res.text().then(function (source) {
             (0, eval)(source);

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -131,6 +131,19 @@ suite('SystemJS Standard Tests', function() {
     });
   });
 
+  test('Errors for bad Content-Type headers', function () {
+    return System.import('fixtures/content-type-none.json')
+    .catch(function (err) {
+      assert.ok(/missing.*content-type.*error#4/i.test(err));
+    })
+    .then(function () {
+      return System.import('fixtures/content-type-xml.json')
+    })
+    .catch(function (err) {
+      assert.ok(/unknown module type.*xml.*error#4/i.test(err));
+    })
+  });
+
   if (typeof Worker !== 'undefined')
   test('Using SystemJS in a Web Worker', function () {
     const worker = new Worker('./browser/worker.js');

--- a/test/fixtures/browser/content-type-none.json
+++ b/test/fixtures/browser/content-type-none.json
@@ -1,0 +1,4 @@
+{
+    "ok": "content but",
+    "no": "content-type"
+}

--- a/test/fixtures/browser/content-type-xml.json
+++ b/test/fixtures/browser/content-type-xml.json
@@ -1,0 +1,3 @@
+{
+    "strange": "content-type header"
+}

--- a/test/server.cjs
+++ b/test/server.cjs
@@ -84,12 +84,15 @@ http.createServer(async function (req, res) {
   let mime;
   if (filePath.endsWith('javascript.css'))
     mime = 'application/javascript';
+  else if (filePath.endsWith('content-type-xml.json'))
+    mime = 'application/xml';
   else
     mime = mimes[path.extname(filePath)] || 'text/plain';
 
-  res.writeHead(200, {
-    'content-type': mime
-  });
+  const headers = filePath.endsWith('content-type-none.json') ?
+    {} : { 'content-type': mime }
+
+  res.writeHead(200, headers);
   fileStream.pipe(res);
   await once(fileStream, 'end');
   res.end();


### PR DESCRIPTION
Currently, if the `Content-Type` header is missing from the response, the error that appears in the console is `TypeError: Cannot read property 'match' of null`. I'd like to preempt that error with a more helpful one, reusing the existing [Error #4](https://github.com/systemjs/systemjs/blob/master/docs/errors.md#4).