### PR TITLE
Fixing browser tests on mocha 7.2.0

### DIFF
--- a/test/browser/amd.js
+++ b/test/browser/amd.js
@@ -1,4 +1,7 @@
 suite('AMD tests', function () {
+  suiteSetup(function() {
+    return System.import('../../dist/extras/amd.js').then(function() {});
+  });
 
   test('Multiple Errors', function () {
     window.onerror = undefined;

--- a/test/browser/named-exports.js
+++ b/test/browser/named-exports.js
@@ -1,5 +1,9 @@
 suite('Named exports', function () {
-  System = new System.constructor();
+  suiteSetup(function() {
+    return System.import('../../dist/extras/named-exports.js').then(function() {
+      System = new System.constructor();
+    });
+  });
 
   test('Loading an AMD module with named exports', function () {
     return System.import('fixtures/amd-module.js').then(function (m) {

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -1,4 +1,8 @@
 suite('Named System.register', function() {
+  suiteSetup(function() {
+    return System.import('../../dist/extras/named-register.js').then(function() {});
+  });
+
   test('Loading a named System.register bundle', function () {
     return System.import('./fixtures/browser/named-bundle.js').then(function (m) {
       assert.equal(m.a, 'b');

--- a/test/browser/transform.js
+++ b/test/browser/transform.js
@@ -1,10 +1,15 @@
 suite('Transform Loader', function() {
-  System = new System.constructor();
   let translateCnt = 0;
-  System.transform = function (url, source) {
-    translateCnt++;
-    return source;
-  };
+
+  suiteSetup(function() {
+    return System.import('../../dist/extras/transform.js').then(function() {
+      System = new System.constructor();
+      System.transform = function (url, source) {
+        translateCnt++;
+        return source;
+      };
+    });
+  });
 
   const supportsWebAssembly = typeof WebAssembly !== 'undefined' && typeof process === 'undefined';
 

--- a/test/server.cjs
+++ b/test/server.cjs
@@ -29,7 +29,7 @@ function setBrowserTimeout () {
     clearTimeout(browserTimeout);
   browserTimeout = setTimeout(() => {
     console.log('No browser requests made to server for 10s, closing.');
-    process.exit(0);
+    process.exit(failTimeout ? 1 : 0);
   }, 10000);
 }
 

--- a/test/test.html
+++ b/test/test.html
@@ -77,6 +77,10 @@
 			mocha.run(function(failures) {
 				fetch(failures ? '/error' : '/done');
 			})
+		})
+		.catch(function(e) {
+			fetch('/error');
+			throw e;
 		});
 	</script>
 

--- a/test/test.html
+++ b/test/test.html
@@ -50,27 +50,33 @@
 			}
 		};
 
-		const extras = ['amd', 'named-exports', 'transform', 'named-register'];
-		let failCnt = 0;
-		function runNextExtra (failures) {
-			failCnt += failures;
-			mocha.suite.suites.shift();
-			const extra = extras.shift();
-			if (extra)
-				System.import('../dist/extras/' + extra + '.js')
-				.then(function () {
-					return System.import('./browser/' + extra + '.js');
-				})
-				.then(function () {
-					mocha.run(runNextExtra);
-				});
-			else
-				fetch(failCnt ? '/error' : '/done');
+		function importNext(name) {
+			return function() {
+				return System.import(name);
+			}
 		}
 
-		System.import('./browser/core.js')
-		.then(function () {
-			mocha.run(runNextExtra);
+		function importSeries() {
+			var promise = Promise.resolve();
+			
+			for(var i=0; i<arguments.length; i++) {
+				promise = promise.then(importNext(arguments[i]));
+			}
+
+			return promise;
+		}
+
+		importSeries(
+			'./browser/core.js',
+			'./browser/amd.js',
+			'./browser/named-exports.js',
+			'./browser/transform.js',
+			'./browser/named-register.js'
+		)
+		.then(function() {
+			mocha.run(function(failures) {
+				fetch(failures ? '/error' : '/done');
+			})
 		});
 	</script>
 


### PR DESCRIPTION
In mocha@7.2.0 the mocha instance is disposed of automatically after the first call of mocha.run and then only the first imported test suite is actually run. This also won't immediately be marked a failure by travis.ci since the exception is never caught and the browser request timeout exits with a 0 code. https://github.com/systemjs/systemjs/blob/435a797920f3e31947845089bafca73cda0e0950/test/server.cjs#L30-L33

The error message given by the browser is:
```
Uncaught (in promise) Error: Mocha instance is already disposed, cannot start a new test run. Please create a new mocha instance. Be sure to set disable `cleanReferencesAfterRun` when you want to reuse the same mocha instance for multiple test runs.
    at createMochaInstanceAlreadyDisposedError (mocha.js:861)
    at Mocha._guardRunningStateTransition (mocha.js:2537)
    at Mocha.run (mocha.js:2585)
    at Mocha.mocha.run (mocha.js:171)
    at test.html:65
```
![image](https://user-images.githubusercontent.com/2154617/86435633-c42d8f00-bd43-11ea-868e-6e676fcb3874.png)

Disabling `cleanReferencesAfterRun` does allow the tests to pass but it is only available on mocha >= 7.2.0 and also results in multiple mocha HTML reporters and a "difficult" to read report on the webpage 
![image](https://user-images.githubusercontent.com/2154617/86436166-1327f400-bd45-11ea-833f-65ef6c90f7e9.png)

This PR moves the import of each extra into an asynchronous `suiteSetup` within the test suite that uses it. The test suites are still imported in series to ensure the original run order.