### PR TITLE
Fix onload

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -78,7 +78,7 @@ In both s.js and system.js, resolve is implemented as a synchronous function.
 
 Resolve should return a fully-valid URL for specification compatibility, but this is not enforced.
 
-#### onload(err, id, deps) (sync)
+#### onload(err, id, deps, isErrSource) (sync)
 
 _This hook is not available in the s.js minimal loader build._
 
@@ -87,6 +87,8 @@ For tracing functionality this is called on completion or failure of each and ev
 `err` is defined for any module load error at instantiation (including fetch and resolution errors), execution or dependency execution.
 
 `deps` is available for errored modules that did not error on instantiation.
+
+`isErrSource` is used to indicate if `id` is the error source or not.
 
 Such tracing can be used for analysis and to clear the loader registry using the `System.delete(url)` API to enable reloading and hot reloading workflows.
 

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -52,8 +52,8 @@ if (!process.env.SYSTEM_PRODUCTION)
 function loadToId (load) {
   return load.id;
 }
-function triggerOnload (loader, load, err) {
-  loader.onload(err, load.id, load.d && load.d.map(loadToId));
+function triggerOnload (loader, load, err, isSource) {
+  loader.onload(err, load.id, load.d && load.d.map(loadToId), !!isSource);
   if (err)
     throw err;
 }
@@ -131,7 +131,7 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
 
   if (!process.env.SYSTEM_PRODUCTION)
     instantiatePromise = instantiatePromise.catch(function (err) {
-      triggerOnload(loader, load, err);
+      triggerOnload(loader, load, err, true);
     });
 
   var linkPromise = instantiatePromise
@@ -155,9 +155,14 @@ function getOrCreateLoad (loader, id, firstParentUrl) {
         });
       })
     }))
-    .then(function (depLoads) {
-      load.d = depLoads;
-    });
+    .then(
+      function (depLoads) {
+        load.d = depLoads;
+      },
+      !process.env.SYSTEM_PRODUCTION && function (err) {
+        triggerOnload(loader, load, err, false);
+      }
+    )
   });
 
   linkPromise.catch(function (err) {
@@ -254,15 +259,17 @@ function postOrderExec (loader, load, seen) {
       catch (err) {
         load.e = null;
         load.er = err;
-        throw err;
+        if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, false);  
+        else throw err;
       }
   });
   if (depLoadPromises)
-    return Promise.all(depLoadPromises).catch(function(err) {
+    return Promise.all(depLoadPromises).then(doExec, function (err) {
       load.e = null;
       load.er = err;
-      throw err;
-    }).then(doExec);
+      if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, false);  
+      else throw err;
+    });
 
   return doExec();
 
@@ -273,22 +280,22 @@ function postOrderExec (loader, load, seen) {
           execPromise = execPromise.then(function () {
             load.C = load.n;
             load.E = null; // indicates completion
-            if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, null);
+            if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, null, true);
           }, function (err) {
             load.er = err;
             load.E = null;
-            if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err);
+            if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, true);
             else throw err;
           });
         return load.E = load.E || execPromise;
       }
       // (should be a promise, but a minify optimization to leave out Promise.resolve)
       load.C = load.n;
-      if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, null);
+      if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, null, true);
     }
     catch (err) {
       load.er = err;
-      if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err);
+      if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, true);
       else throw err;
     }
     finally {

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -52,8 +52,8 @@ if (!process.env.SYSTEM_PRODUCTION)
 function loadToId (load) {
   return load.id;
 }
-function triggerOnload (loader, load, err, isSource) {
-  loader.onload(err, load.id, load.d && load.d.map(loadToId), !!isSource);
+function triggerOnload (loader, load, err, isErrSource) {
+  loader.onload(err, load.id, load.d && load.d.map(loadToId), !!isErrSource);
   if (err)
     throw err;
 }

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -270,18 +270,15 @@ function postOrderExec (loader, load, seen) {
     try {
       var execPromise = load.e.call(nullContext);
       if (execPromise) {
-        if (!process.env.SYSTEM_PRODUCTION)
           execPromise = execPromise.then(function () {
             load.C = load.n;
             load.E = null; // indicates completion
-            triggerOnload(loader, load, null);
+            if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, null);
           }, function (err) {
-            triggerOnload(loader, load, err);
-          });
-        else
-          execPromise = execPromise.then(function () {
-            load.C = load.n;
+            load.er = err;
             load.E = null;
+            if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err);
+            else throw err;
           });
         return load.E = load.E || execPromise;
       }


### PR DESCRIPTION
Currently tracking hook onload will be called multiple times when one of dep execution failed, this request aims to align the error handle as instantiate 