### PR TITLE
Update system-core.js

### DIFF
--- a/src/system-core.js
+++ b/src/system-core.js
@@ -306,4 +306,4 @@ function postOrderExec (loader, load, seen) {
   }
 }
 
-global.system  = global.system || new SystemJS();}
+global.system  = global.System || new SystemJS();}

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -306,4 +306,4 @@ function postOrderExec (loader, load, seen) {
   }
 }
 
-global.System = new SystemJS();
+global.system  = global.system || new SystemJS();}


### PR DESCRIPTION
Only set it if it does not got already loaded by a other instance. Maybe add console.log('Already Loaded')

@rollup we have a request to inline the systemjs loader into every entrypoint. I know it is not the best idea but i do not want to maintain a extra fork of systemjs for that.

and i documented already that it is more clever to solve it in a other way.

at present i workaround like this

```js
/Transform SystemJS.min file to assign SystemJS only if it is not already loaded needed to be loaded more then once in multiple entrypoints
const transformMinifiedSystemJSVersion = (minSystemJS)=>{
    let [start,end] = minSystemJS.toString('utf8').split('.System=new ');
    const globalVarName = start.charAt(start.length - 1); // 'm'
    return `${start}.System=${globalVarName}.System || new ${end}`
}


//if you use output name you need to include the systemjs loader with extra register named module
import fs from 'fs'
export default {
    input: './src/test.js',
    output: {
        file: './src/test.systemjs.js',
        banner: transformMinifiedSystemJSVersion(fs.readFileSync('./node_modules/systemjs/dist/s.min.js')),
        footer: `System.getRegister()[1]({},System).execute()`,
        format: 'systemjs',
    }
}
```