### PR TITLE
Add auto-import extra

### DIFF
--- a/src/extras/auto-import.js
+++ b/src/extras/auto-import.js
@@ -15,14 +15,6 @@
     // register normally
     systemRegister.call(this, deps, declare);
 
-    // save the current url, and pass it to `importLastRegisterAs`
-    var scripts = document.getElementsByTagName("script");
-    var scriptUrl = scripts[scripts.length - 1].src || document.baseURI;
-    systemJSPrototype.importLastRegisterAs.call(this, scriptUrl);
-  };
-
-  // import the last register, but use id and parentUrl as
-  systemJSPrototype.importLastRegisterAs = function () {
     // retrieve last register
     var register = systemGetRegister.call(this);
     
@@ -37,7 +29,12 @@
       });
     };
 
+    // save the current url
+    // if it was not a external file, the script was inline so use baseURI
+    var scripts = document.getElementsByTagName("script");
+    var scriptUrl = scripts[scripts.length - 1].src || document.baseURI;
+    
     // do the actual import
-    systemJSPrototype.import.apply(this, arguments);
+    systemJSPrototype.import.call(this, scriptUrl);
   };
 })(typeof self !== "undefined" ? self : global);

--- a/src/extras/auto-import.js
+++ b/src/extras/auto-import.js
@@ -1,0 +1,43 @@
+/**
+ * Auto-import the first call to System.register 
+ */
+(function (global) {
+  var systemJSPrototype = global.System.constructor.prototype;
+  var systemInstantiate = systemJSPrototype.instantiate;
+  var systemRegister = systemJSPrototype.register;
+  var systemGetRegister = systemJSPrototype.getRegister;
+
+  // hook into System.register (but release it after first usage)
+  systemJSPrototype.register = function (deps, declare) {
+    // reset System.register for subsequent usage
+    systemJSPrototype.register = systemRegister;
+
+    // register normally
+    systemRegister.call(this, deps, declare);
+
+    // save the current url, and pass it to `importLastRegisterAs`
+    var scripts = document.getElementsByTagName("script");
+    var scriptUrl = scripts[scripts.length - 1].src || document.baseURI;
+    systemJSPrototype.importLastRegisterAs.call(this, scriptUrl);
+  };
+
+  // import the last register, but use id and parentUrl as
+  systemJSPrototype.importLastRegisterAs = function () {
+    // retrieve last register
+    var register = systemGetRegister.call(this);
+    
+    // hook into System.instantiate (but release it after first usage)
+    systemJSPrototype.instantiate = function () {
+      // reset System.instantiate for subsequent usage
+      systemJSPrototype.instantiate = systemInstantiate;
+      
+      return new Promise(function (resolve) {
+        // resolve with the last register
+        resolve(register);
+      });
+    };
+
+    // do the actual import
+    systemJSPrototype.import.apply(this, arguments);
+  };
+})(typeof self !== "undefined" ? self : global);

--- a/src/extras/auto-import.js
+++ b/src/extras/auto-import.js
@@ -1,5 +1,5 @@
 /**
- * Auto-import the first call to System.register 
+ * Auto-import all calls to System.register during loading 
  */
 (function (global) {
   var systemJSPrototype = global.System.constructor.prototype;
@@ -7,13 +7,13 @@
   var systemRegister = systemJSPrototype.register;
   var systemGetRegister = systemJSPrototype.getRegister;
 
-  // hook into System.register (but release it after first usage)
+  // hook into System.register
   systemJSPrototype.register = function (deps, declare) {
-    // reset System.register for subsequent usage
-    systemJSPrototype.register = systemRegister;
-
     // register normally
     systemRegister.call(this, deps, declare);
+
+    // only auto import if the document is not loading
+    if (document.readyState !== 'loading') return;
 
     // retrieve last register
     var register = systemGetRegister.call(this);


### PR DESCRIPTION
This PR might solve #2148. 

It introduces a pluggable extra "auto-import". The extra will auto-import the first register and will try to deduce what the url for it was. (either the current running js file, or in case of inline the baseURI.

Some comments:
- I didn't add any additional files/test or changed anything else (yet), as I'm not sure how you guys feel about it.
- Not sure about the `importLastRegisterAs` function being hookable. It seemed the right thing to do in order to allow other extra's to change the way the url is retrieved.
- I only used the case of an external src.
- I already tried to write the code as a real extra.