### PR TITLE
Dynamic maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following [pluggable extras](dist/extras) can be dropped in with either the 
 * [Named exports](dist/extras/named-exports.js) convenience extension support for global and AMD module formats (`import { x } from './global.js'` instead of `import G from './global.js'; G.x`)
 * [Named register](dist/extras/named-register.js) supports `System.register('name', ...)` named bundles which can then be imported as `System.import('name')` (as well as AMD named define support)
 * [Transform loader](dist/extras/transform.js) support, using fetch and eval, supporting a hookable `loader.transform`
-* [Dynamic import maps](dist/extras/dynamic-import-maps.js) support. This is currently a _potential_ new standard [feature](https://github.com/guybedford/import-maps-extensions).
+* [Dynamic import maps](dist/extras/dynamic-import-maps.js) support. This is currently a _potential_ new standard [feature](https://github.com/guybedford/import-maps-extensions#lazy-loading-of-import-maps).
 
 The following extras are included in system.js loader by default, and can be added to the s.js loader for a smaller tailored footprint:
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following [pluggable extras](dist/extras) can be dropped in with either the 
 * [Named exports](dist/extras/named-exports.js) convenience extension support for global and AMD module formats (`import { x } from './global.js'` instead of `import G from './global.js'; G.x`)
 * [Named register](dist/extras/named-register.js) supports `System.register('name', ...)` named bundles which can then be imported as `System.import('name')` (as well as AMD named define support)
 * [Transform loader](dist/extras/transform.js) support, using fetch and eval, supporting a hookable `loader.transform`
+* [Dynamic import maps](dist/extras/dynamic-import-maps.js) support. This is currently a _potential_ new standard [feature](https://github.com/guybedford/import-maps-extensions).
 
 The following extras are included in system.js loader by default, and can be added to the s.js loader for a smaller tailored footprint:
 

--- a/src/extras/dynamic-import-maps.js
+++ b/src/extras/dynamic-import-maps.js
@@ -1,30 +1,16 @@
 /*
  * Support for live DOM updating import maps
  */
-(function () {
-  function handleMutation (mutations) {
-    var reparse = false;
-
-    for (var i = 0; i < mutations.length; i++) {
-      var mutation = mutations[i];
-      if (mutation.type !== 'childList')
-        continue;
-      for (var j = 0; j < mutation.addedNodes.length; j++) {
-        var addedNode = mutation.addedNodes[j];
-        if (addedNode.tagName === 'SCRIPT' && addedNode.type === 'systemjs-importmap' && !addedNode.sp) {
-          reparse = true;
-          break;
-        }
+new MutationObserver(function (mutations) {
+  for (var i = 0; i < mutations.length; i++) {
+    var mutation = mutations[i];
+    if (mutation.type === 'childList')
+    for (var j = 0; j < mutation.addedNodes.length; j++) {
+      var addedNode = mutation.addedNodes[j];
+      if (addedNode.tagName === 'SCRIPT' && addedNode.type === 'systemjs-importmap' && !addedNode.sp) {
+        System.prepareImport(true);
+        break;
       }
     }
-
-    if (reparse)
-      System.prepareImport(true);
   }
-
-  new MutationObserver(handleMutation).observe(document.documentElement, {
-    attributes: false,
-    childList: true,
-    subtree: true
-  });
-})();
+}).observe(document, { childList: true, subtree: true });

--- a/src/extras/dynamic-import-maps.js
+++ b/src/extras/dynamic-import-maps.js
@@ -11,7 +11,7 @@
         continue;
       for (var j = 0; j < mutation.addedNodes.length; j++) {
         var addedNode = mutation.addedNodes[j];
-        if (addedNode.tagName === 'SCRIPT' && addedNode.type === 'systemjs-importmap') {
+        if (addedNode.tagName === 'SCRIPT' && addedNode.type === 'systemjs-importmap' && !addedNode.sp) {
           reparse = true;
           break;
         }

--- a/src/extras/dynamic-import-maps.js
+++ b/src/extras/dynamic-import-maps.js
@@ -1,0 +1,49 @@
+/*
+ * Support for live DOM updating import maps
+ */
+(function (global) {
+  var systemJSPrototype = global.System.constructor.prototype;
+
+  function flagForReparse (element) {
+    element[systemJSPrototype.IMPORT_MAP_PARSED] = false;
+  }
+
+  function handleMutation (mutations) {
+    var reparse = false;
+
+    mutations.forEach(function (mutation) {
+      switch (mutation.type) {
+        case 'attributes':
+          if (mutation.attributeName === 'src' && isImportMapElement(mutation.target)) {
+            flagForReparse(mutation.target);
+            reparse = true;
+          }
+          break;
+
+        case 'childList':
+          var addedNodes = mutation.addedNodes;
+          for (var i=0; i<addedNodes.length; i++) {
+            if (isImportMapElement(addedNodes[i])) {
+              flagForReparse(addedNodes[i]);
+              reparse = true;
+            }
+          }
+          break;
+      }
+    });
+
+    if (reparse) {
+      System.prepareImport(true);
+    }
+  }
+
+  function isImportMapElement (element) {
+    return element.nodeType === Node.ELEMENT_NODE && element.tagName === 'SCRIPT' && element.type === 'systemjs-importmap';
+  }
+
+  new MutationObserver(handleMutation).observe(document.documentElement, {
+    attributes: true,
+    childList: true,
+    subtree: true
+  });
+})(typeof self !== 'undefined' ? self : global);

--- a/src/features/browser-scripts.js
+++ b/src/features/browser-scripts.js
@@ -28,15 +28,16 @@ if (hasDocument) {
 
 function processScripts () {
   [].forEach.call(document.querySelectorAll('script'), function (script) {
+    if (script.sp) // sp marker = systemjs processed
+      return;
     // TODO: deprecate systemjs-module in next major now that we have auto import
     if (script.type === 'systemjs-module') {
+      script.sp = true;
       if (!script.src)
         return;
       System.import(script.src.slice(0, 7) === 'import:' ? script.src.slice(7) : resolveUrl(script.src, baseUrl));
     }
     else if (script.type === 'systemjs-importmap') {
-      if (script.sp) // sp marker = systemjs processed
-        return;
       script.sp = true;
       importMapPromise = importMapPromise.then(function (importMap) {
         if (script.src)

--- a/src/features/browser-scripts.js
+++ b/src/features/browser-scripts.js
@@ -1,7 +1,7 @@
 /*
  * SystemJS browser attachments for script and import map processing
  */
-import { baseUrl, resolveAndComposeImportMap, hasDocument, IMPORT_MAP, resolveUrl } from '../common.js';
+import { baseUrl, resolveAndComposeImportMap, hasDocument, resolveUrl, IMPORT_MAP } from '../common.js';
 import { systemJSPrototype } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
 
@@ -11,8 +11,8 @@ var importMapPromise = Promise.resolve({ imports: {}, scopes: {} });
 // Import map scripts are processed only once (by being marked) and in order for each phase.
 // This is to avoid using DOM mutation observers in core, although that would be an alternative.
 var processFirst = hasDocument;
-systemJSPrototype.prepareImport = function () {
-  if (processFirst) {
+systemJSPrototype.prepareImport = function (doProcessScripts) {
+  if (processFirst || doProcessScripts) {
     processScripts();
     processFirst = false;
   }

--- a/test/browser/dynamic-import-maps.js
+++ b/test/browser/dynamic-import-maps.js
@@ -69,22 +69,4 @@ suite('Dynamic import maps', () => {
     appendImportMap({ src: 'fixtures/browser/dynamic-importmap1.json' });
     return importAfterImportMap(moduleId);
   });
-
-  test('Loading modified elements (inline)', async () => {
-    const moduleId = 'dynamic-inline-map-2';
-    const otherModuleId = `${moduleId}--other`;
-    appendImportMap({ moduleId: otherModuleId });
-    await importNonExistent(moduleId);
-    editImportMap({ needleModuleId: otherModuleId, newModuleId: moduleId });
-    return importAfterImportMap(moduleId);
-  });
-
-  test('Loading modified elements (external)', async () => {
-    const moduleId = 'dynamic-external-map-2';
-    const orgSrc = 'fixtures/browser/dynamic-importmap1.json';
-    appendImportMap({ src: orgSrc });
-    await importNonExistent(moduleId);
-    editImportMap({ needleSrc: orgSrc, newSrc: 'fixtures/browser/dynamic-importmap2.json' });
-    return importAfterImportMap(moduleId);
-  });
 });

--- a/test/browser/dynamic-import-maps.js
+++ b/test/browser/dynamic-import-maps.js
@@ -1,0 +1,90 @@
+const externalModule = 'fixtures/esm.js';
+const IMPORT_MAP_TYPE = 'systemjs-importmap';
+
+const appendImportMap = ({ moduleId, src }) => {
+  const script = document.createElement('script');
+  script.type = IMPORT_MAP_TYPE;
+
+  if (src) {
+    script.async = true; // avoid theoretical timing issues
+    script.src = src;
+  }
+
+  if (moduleId) {
+    script.textContent = JSON.stringify({ imports: { [moduleId]: externalModule } });
+  }
+
+  container.append(script);
+  return script;
+};
+
+const editImportMap = ({ needleModuleId, needleSrc, newModuleId, newSrc }) => {
+  const importMapType = `script[type="${IMPORT_MAP_TYPE}"]`;
+  if (needleModuleId && newModuleId) {
+    [...document.querySelectorAll(importMapType)]
+      .filter(element => element.textContent.includes(needleModuleId))
+      .forEach(element => element.textContent = element.textContent.replace(needleModuleId, newModuleId));
+  } else if (needleSrc && newSrc) {
+    document.querySelector(`${importMapType}[src="${needleSrc}"]`).src = newSrc;
+  } else {
+    throw new Error('Incorrect configuration');
+  }
+};
+
+const importAfterImportMap = id => new Promise(resolve => setTimeout(resolve, 10)).then(() => {
+  return System.import(id);
+});
+
+const importNonExistent = id => System.import(id)
+  .catch(error => error)
+  .then(result => {
+    if (!(result instanceof Error)) {
+      throw new Error(`Unexpected mapping found for module "${id}"`);
+    }
+  });
+
+let container;
+
+suite('Dynamic import maps', () => {
+  suiteSetup(() => System.import('../../dist/extras/dynamic-import-maps.js'));
+
+  setup(() => {
+    container = document.createElement('div');
+    container.id = 'importmap-container';
+    document.body.append(container);
+  });
+
+  teardown(() => container.remove());
+
+  test('Loading newly added elements (inline)', async () => {
+    const moduleId = 'dynamic-inline-map-1';
+    await importNonExistent(moduleId);
+    appendImportMap({ moduleId });
+    return importAfterImportMap(moduleId);
+  });
+
+  test('Loading newly added elements (external)', async () => {
+    const moduleId = 'dynamic-external-map-1';
+    await importNonExistent(moduleId);
+    appendImportMap({ src: 'fixtures/browser/dynamic-importmap1.json' });
+    return importAfterImportMap(moduleId);
+  });
+
+  test('Loading modified elements (inline)', async () => {
+    const moduleId = 'dynamic-inline-map-2';
+    const otherModuleId = `${moduleId}--other`;
+    appendImportMap({ moduleId: otherModuleId });
+    await importNonExistent(moduleId);
+    editImportMap({ needleModuleId: otherModuleId, newModuleId: moduleId });
+    return importAfterImportMap(moduleId);
+  });
+
+  test('Loading modified elements (external)', async () => {
+    const moduleId = 'dynamic-external-map-2';
+    const orgSrc = 'fixtures/browser/dynamic-importmap1.json';
+    appendImportMap({ src: orgSrc });
+    await importNonExistent(moduleId);
+    editImportMap({ needleSrc: orgSrc, newSrc: 'fixtures/browser/dynamic-importmap2.json' });
+    return importAfterImportMap(moduleId);
+  });
+});

--- a/test/fixtures/browser/dynamic-importmap1.json
+++ b/test/fixtures/browser/dynamic-importmap1.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "dynamic-external-map-1": "./esm.js"
+  }
+}

--- a/test/fixtures/browser/dynamic-importmap2.json
+++ b/test/fixtures/browser/dynamic-importmap2.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "dynamic-external-map-2": "./esm.js"
+  }
+}

--- a/test/test.html
+++ b/test/test.html
@@ -72,24 +72,12 @@
 			'./browser/amd.js',
 			'./browser/named-exports.js',
 			'./browser/transform.js',
-			'./browser/named-register.js',
-			'./browser/dynamic-import-maps.js'
+			'./browser/named-register.js'
 		)
 		.then(function() {
-			mocha
-				.rootHooks({
-					// @todo we need an "after each suite": https://github.com/mochajs/mocha/issues/4039
-					afterEach: function() {
-						var c = System.constructor.prototype;
-						var importMapElements = document.querySelectorAll(c.IMPORT_MAP_SELECTOR);
-						for (var i=0; i<importMapElements.length; i++) {
-							importMapElements[i][c.IMPORT_MAP_PARSED] = false;
-						}
-					}
-				})
-				.run(function(failures) {
-					fetch(failures ? '/error' : '/done');
-				});
+			mocha.run(function(failures) {
+				fetch(failures ? '/error' : '/done');
+			})
 		})
 		.catch(function(e) {
 			fetch('/error');

--- a/test/test.html
+++ b/test/test.html
@@ -72,7 +72,8 @@
 			'./browser/amd.js',
 			'./browser/named-exports.js',
 			'./browser/transform.js',
-			'./browser/named-register.js'
+			'./browser/named-register.js',
+			'./browser/dynamic-import-maps.js'
 		)
 		.then(function() {
 			mocha

--- a/test/test.html
+++ b/test/test.html
@@ -75,9 +75,20 @@
 			'./browser/named-register.js'
 		)
 		.then(function() {
-			mocha.run(function(failures) {
-				fetch(failures ? '/error' : '/done');
-			})
+			mocha
+				.rootHooks({
+					// @todo we need an "after each suite": https://github.com/mochajs/mocha/issues/4039
+					afterEach: function() {
+						var c = System.constructor.prototype;
+						var importMapElements = document.querySelectorAll(c.IMPORT_MAP_SELECTOR);
+						for (var i=0; i<importMapElements.length; i++) {
+							importMapElements[i][c.IMPORT_MAP_PARSED] = false;
+						}
+					}
+				})
+				.run(function(failures) {
+					fetch(failures ? '/error' : '/done');
+				});
 		})
 		.catch(function(e) {
 			fetch('/error');

--- a/test/test.html
+++ b/test/test.html
@@ -72,7 +72,8 @@
 			'./browser/amd.js',
 			'./browser/named-exports.js',
 			'./browser/transform.js',
-			'./browser/named-register.js'
+			'./browser/named-register.js',
+			'./browser/dynamic-import-maps.js'
 		)
 		.then(function() {
 			mocha.run(function(failures) {


### PR DESCRIPTION
This is a follow-on to https://github.com/systemjs/systemjs/pull/2215, with support for dynamic maps rebased to the latest master.

@stevenvachon I've removed the attribute changes triggering updates because that is not a feature that import maps would ever be able to specifying in browsers themselves. Dynamic injections are processed on the moment they are inserted into the DOM, just like script tags.