### PR TITLE
Define s.js as an export

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
       "node": "./dist/system-node.cjs",
       "default": "./dist/system.min.js"
     },
+    "./s.js": "./dist/s.min.js",
     "./dist/": "./dist/"
   },
   "description": "Dynamic ES module loader",


### PR DESCRIPTION
This explicitly defines the `s.js` loader as an export in exports allowing an easier `systemjs/s.js` resolution.