### PR TITLE
Implement integrity in import map

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -150,16 +150,14 @@ function resolveAndComposePackages (packages, outPackages, baseUrl, parentMap, p
   }
 }
 
-export function resolveAndComposeImportMap (json, baseUrl, parentMap) {
-  var outMap = { imports: objectAssign({}, parentMap.imports), scopes: objectAssign({}, parentMap.scopes), depcache: objectAssign({}, parentMap.depcache), integrity: objectAssign({}, parentMap.integrity) };
-
+export function resolveAndComposeImportMap (json, baseUrl, outMap) {
   if (json.imports)
-    resolveAndComposePackages(json.imports, outMap.imports, baseUrl, parentMap, null);
+    resolveAndComposePackages(json.imports, outMap.imports, baseUrl, outMap, null);
 
   var u;
   for (u in json.scopes || {}) {
     var resolvedScope = resolveUrl(u, baseUrl);
-    resolveAndComposePackages(json.scopes[u], outMap.scopes[resolvedScope] || (outMap.scopes[resolvedScope] = {}), baseUrl, parentMap, resolvedScope);
+    resolveAndComposePackages(json.scopes[u], outMap.scopes[resolvedScope] || (outMap.scopes[resolvedScope] = {}), baseUrl, outMap, resolvedScope);
   }
 
   for (u in json.depcache || {})
@@ -167,8 +165,6 @@ export function resolveAndComposeImportMap (json, baseUrl, parentMap) {
   
   for (u in json.integrity || {})
     outMap.integrity[resolveUrl(u, baseUrl)] = json.integrity[u];
-
-  return outMap;
 }
 
 function getMatch (path, matchObj) {

--- a/src/common.js
+++ b/src/common.js
@@ -125,12 +125,6 @@ export function resolveUrl (relUrl, parentUrl) {
   return resolveIfNotPlainOrUrl(relUrl, parentUrl) || (relUrl.indexOf(':') !== -1 ? relUrl : resolveIfNotPlainOrUrl('./' + relUrl, parentUrl));
 }
 
-function objectAssign (to, from) {
-  for (var p in from)
-    to[p] = from[p];
-  return to;
-}
-
 function resolveAndComposePackages (packages, outPackages, baseUrl, parentMap, parentUrl) {
   for (var p in packages) {
     var resolvedLhs = resolveIfNotPlainOrUrl(p, baseUrl) || p;

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -47,14 +47,14 @@ function processScripts () {
     }
     else if (script.type === 'systemjs-importmap') {
       script.sp = true;
+      var fetchPromise = script.src ? fetch(script.src).then(function (res) {
+        return res.text();
+      }) : script.innerHTML;
       importMapPromise = importMapPromise.then(function () {
-        if (script.src)
-          return fetch(script.src).then(function (res) {
-            return res.text();
-          }).then(function (text) {
-            importMap = extendImportMap(importMap, text, script.src);
-          });
-        importMap = extendImportMap(importMap, script.innerHTML, baseUrl);
+        return fetchPromise;
+      })
+      .then(function (text) {
+        extendImportMap(importMap, text, script.src);
       });
     }
   });
@@ -66,5 +66,5 @@ function extendImportMap (importMap, newMapText, newMapUrl) {
   } catch (err) {
     throw Error(process.env.SYSTEM_PRODUCTION ? errMsg(1) : errMsg(1, "systemjs-importmap contains invalid JSON"));
   }
-  return resolveAndComposeImportMap(newMap, newMapUrl, importMap);
+  resolveAndComposeImportMap(newMap, newMapUrl, importMap);
 }

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -5,7 +5,8 @@ import { baseUrl, resolveAndComposeImportMap, hasDocument, resolveUrl, IMPORT_MA
 import { systemJSPrototype, getOrCreateLoad } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
 
-var importMapPromise = Promise.resolve({ imports: {}, scopes: {}, depcache: {} });
+var importMapPromise = Promise.resolve();
+export var importMap = { imports: {}, scopes: {}, depcache: {}, integrity: {} };
 
 // Scripts are processed immediately, on the first System.import, and on DOMReady.
 // Import map scripts are processed only once (by being marked) and in order for each phase.
@@ -16,10 +17,7 @@ systemJSPrototype.prepareImport = function (doProcessScripts) {
     processScripts();
     processFirst = false;
   }
-  var loader = this;
-  return importMapPromise.then(function (importMap) {
-    loader[IMPORT_MAP] = importMap;
-  });
+  return importMapPromise;
 };
 if (hasDocument) {
   processScripts();
@@ -28,7 +26,7 @@ if (hasDocument) {
 
 var systemInstantiate = systemJSPrototype.instantiate;
 systemJSPrototype.instantiate = function (url, firstParentUrl) {
-  var preloads = this[IMPORT_MAP].depcache[url];
+  var preloads = (!process.env.SYSTEM_BROWSER && this[IMPORT_MAP] || importMap).depcache[url];
   if (preloads) {
     for (var i = 0; i < preloads.length; i++)
       getOrCreateLoad(this, this.resolve(preloads[i], url), url);
@@ -49,14 +47,14 @@ function processScripts () {
     }
     else if (script.type === 'systemjs-importmap') {
       script.sp = true;
-      importMapPromise = importMapPromise.then(function (importMap) {
+      importMapPromise = importMapPromise.then(function () {
         if (script.src)
           return fetch(script.src).then(function (res) {
             return res.text();
           }).then(function (text) {
-            return extendImportMap(importMap, text, script.src);
+            importMap = extendImportMap(importMap, text, script.src);
           });
-        return extendImportMap(importMap, script.innerHTML, baseUrl);
+        importMap = extendImportMap(importMap, script.innerHTML, baseUrl);
       });
     }
   });

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -52,9 +52,8 @@ function processScripts () {
       }) : script.innerHTML;
       importMapPromise = importMapPromise.then(function () {
         return fetchPromise;
-      })
-      .then(function (text) {
-        extendImportMap(importMap, text, script.src);
+      }).then(function (text) {
+        extendImportMap(importMap, text, script.src || baseUrl);
       });
     }
   });

--- a/src/features/resolve.js
+++ b/src/features/resolve.js
@@ -1,10 +1,11 @@
 import { BASE_URL, baseUrl, resolveImportMap, resolveIfNotPlainOrUrl, IMPORT_MAP } from '../common.js';
+import { importMap } from './import-maps.js';
 import { systemJSPrototype } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
 
 systemJSPrototype.resolve = function (id, parentUrl) {
   parentUrl = parentUrl || !process.env.SYSTEM_BROWSER && this[BASE_URL] || baseUrl;
-  return resolveImportMap(this[IMPORT_MAP], resolveIfNotPlainOrUrl(id, parentUrl) || id, parentUrl) || throwUnresolved(id, parentUrl);
+  return resolveImportMap((!process.env.SYSTEM_BROWSER && this[IMPORT_MAP] || importMap), resolveIfNotPlainOrUrl(id, parentUrl) || id, parentUrl) || throwUnresolved(id, parentUrl);
 };
 
 function throwUnresolved (id, parentUrl) {

--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -1,9 +1,10 @@
 /*
  * Script instantiation loading
  */
-import { hasDocument } from '../common.js';
+import { hasDocument, IMPORT_MAP } from '../common.js';
 import { systemJSPrototype } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
+import { importMap } from './import-maps.js';
 
 if (hasDocument) {
   window.addEventListener('error', function (evt) {
@@ -22,6 +23,9 @@ systemJSPrototype.createScript = function (url) {
   // - https://bugs.webkit.org/show_bug.cgi?id=171566
   if (!url.startsWith(baseOrigin + '/'))
     script.crossOrigin = 'anonymous';
+  var integrity = importMap.integrity[url];
+  if (integrity)
+    script.integrity = integrity;
   script.src = url;
   return script;
 };

--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -1,7 +1,7 @@
 /*
  * Script instantiation loading
  */
-import { hasDocument, IMPORT_MAP } from '../common.js';
+import { hasDocument } from '../common.js';
 import { systemJSPrototype } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
 import { importMap } from './import-maps.js';

--- a/src/system-node.js
+++ b/src/system-node.js
@@ -25,7 +25,8 @@ systemJSPrototype.resolve = function () {
 
 export function applyImportMap(loader, newMap, mapBase) {
   ensureValidSystemLoader(loader);
-  loader[IMPORT_MAP] = resolveAndComposeImportMap(newMap, mapBase || baseUrl, loader[IMPORT_MAP] || { imports: {}, scopes: {} });
+  loader[IMPORT_MAP] = loader[IMPORT_MAP] || { imports: {}, scopes: {} };
+  resolveAndComposeImportMap(newMap, mapBase || baseUrl, loader[IMPORT_MAP]);
   loader[IMPORT_MAP_PROMISE] = Promise.resolve();
 }
 

--- a/test/fixtures/browser/importmap.json
+++ b/test/fixtures/browser/importmap.json
@@ -31,5 +31,8 @@
     "depcache7.js": ["./depcache8.js"],
     "depcache8.js": ["./depcache9.js"],
     "depcache9.js": ["./depcache10.js"]
+  },
+  "integrity": {
+    "./depcache7.js": "sha384-LCvjADCTfAR3k6tCcnOrjSzC4Zjcp1o3e2zeX8c41pdo9i4cTAfQzG1fRESuhAS4"
   }
 }


### PR DESCRIPTION
This implements a new `"integrity"` attribute in the import map, which is consulted when creating scripts for injection to use as the primary integrity mechanism.

In this way a full integrity content security policy can be applied to apps built on top of SystemJS.

Like depcache this is non-standard right now, but I have put together a rough standard outline in the import maps extensions repo at https://github.com/guybedford/import-maps-extensions#integrity.