### PR TITLE
import.meta.resolve implementation

### DIFF
--- a/src/system-core.js
+++ b/src/system-core.js
@@ -41,8 +41,12 @@ systemJSPrototype.import = function (id, parentUrl) {
 
 // Hookable createContext function -> allowing eg custom import meta
 systemJSPrototype.createContext = function (parentId) {
+  var loader = this;
   return {
-    url: parentId
+    url: parentId,
+    resolve: function (id, parentUrl) {
+      return Promise.resolve(loader.resolve(id, parentUrl || parentId));
+    }
   };
 };
 

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -57,10 +57,48 @@ suite('SystemJS Standard Tests', function() {
     });
   });
 
+  test('import.meta.resolve package maps', function () {
+    return System.import('fixtures/resolve.js').then(function (m) {
+      return m.resolve('a')
+    })
+    .then(function (resolved) {
+      assert.equal(resolved, rootURL + 'b');
+    });
+  });
+
+  test('import.meta.resolve package maps paths', function () {
+    return System.import('fixtures/resolve.js').then(function (m) {
+      return m.resolve('a/')
+    })
+    .then(function (resolved) {
+      assert.equal(resolved, baseURL + 'fixtures/browser/a/');
+    });
+  });
+
   test('Contextual package maps', function () {
     return System.import('fixtures/scope-test/index.js')
     .then(function (m) {
       assert.equal(m.mapdep, 'mapdep');
+    });
+  });
+
+  test('import.meta.resolve contextual package maps', function () {
+    return System.import('fixtures/resolve.js').then(function (m) {
+      return m.resolve('maptest', baseURL + 'fixtures/browser/scope-test/index.js')
+    })
+    .then(function (resolved) {
+      assert.equal(resolved, baseURL + 'fixtures/browser/contextual-map-dep.js');
+    });
+  });
+
+  test('import.meta.resolve contextual package maps fail', function () {
+    return System.import('fixtures/resolve.js').then(function (m) {
+      return m.resolve('maptest')
+    })
+    .then(function (resolved) {
+      assert.ok(false);
+    }, function (error) {
+      assert.equal(error.message.indexOf('Unable to resolve'), 0);
     });
   });
 
@@ -217,6 +255,15 @@ suite('SystemJS Standard Tests', function() {
     const resolved = System.resolve('/test/fixtures/browser/auto-import.js');
     assert.ok(System.has(resolved));
     assert.equal(System.get(resolved).auto, 'import');
+  });
+
+  test('import.meta.resolve', function () {
+    return System.import('fixtures/resolve.js').then(function (m) {
+      return m.resolve('./test.js')
+    })
+    .then(function (resolved) {
+      assert.equal(resolved, baseURL + 'fixtures/browser/test.js');
+    });
   });
 
   test('non-enumerable __esModule property export (issue 2090)', function () {

--- a/test/fixtures/browser/resolve.js
+++ b/test/fixtures/browser/resolve.js
@@ -1,0 +1,11 @@
+System.register([], function (_export, _context) {
+  return {
+    setters: [],
+    execute: function () {
+      _export({
+        url: _context.meta.url,
+        resolve: _context.meta.resolve
+      });
+    }
+  };
+});


### PR DESCRIPTION
This implements an `import.meta.resolve` function on the SystemJS context in core allowing contextual resolution for native ES modules converted into the SystemJS format.

This is as landed in ES Module Shims here - https://github.com/guybedford/es-module-shims/pull/89.

By default the implementation is async to support an async resolver function. In future if this is ever made sync that will be an easier hence starting with an async hook makes the most sense. This also matches the implementation under `--experimental-import-meta-resolve` in Node.js.