### PR TITLE
Fixup depcache

### DIFF
--- a/src/features/depcache.js
+++ b/src/features/depcache.js
@@ -1,0 +1,13 @@
+import { IMPORT_MAP } from '../common.js';
+import { systemJSPrototype, getOrCreateLoad } from '../system-core.js';
+import { importMap } from './import-maps.js';
+
+var systemInstantiate = systemJSPrototype.instantiate;
+systemJSPrototype.instantiate = function (url, firstParentUrl) {
+  var preloads = (!process.env.SYSTEM_BROWSER && this[IMPORT_MAP] || importMap).depcache[url];
+  if (preloads) {
+    for (var i = 0; i < preloads.length; i++)
+      getOrCreateLoad(this, this.resolve(preloads[i], url), url);
+  }
+  return systemInstantiate.call(this, url, firstParentUrl);
+};

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -1,8 +1,8 @@
 /*
  * SystemJS browser attachments for script and import map processing
  */
-import { baseUrl, resolveAndComposeImportMap, hasDocument, resolveUrl, IMPORT_MAP } from '../common.js';
-import { systemJSPrototype, getOrCreateLoad } from '../system-core.js';
+import { baseUrl, resolveAndComposeImportMap, hasDocument, resolveUrl } from '../common.js';
+import { systemJSPrototype } from '../system-core.js';
 import { errMsg } from '../err-msg.js';
 
 var importMapPromise = Promise.resolve();
@@ -23,16 +23,6 @@ if (hasDocument) {
   processScripts();
   window.addEventListener('DOMContentLoaded', processScripts);
 }
-
-var systemInstantiate = systemJSPrototype.instantiate;
-systemJSPrototype.instantiate = function (url, firstParentUrl) {
-  var preloads = (!process.env.SYSTEM_BROWSER && this[IMPORT_MAP] || importMap).depcache[url];
-  if (preloads) {
-    for (var i = 0; i < preloads.length; i++)
-      getOrCreateLoad(this, this.resolve(preloads[i], url), url);
-  }
-  return systemInstantiate.call(this, url, firstParentUrl);
-};
 
 function processScripts () {
   [].forEach.call(document.querySelectorAll('script'), function (script) {

--- a/src/s.js
+++ b/src/s.js
@@ -1,4 +1,5 @@
 import './features/script-load.js';
 import './features/resolve.js';
 import './features/import-maps.js';
+import './features/depcache.js';
 import './features/worker-load.js';

--- a/src/system.js
+++ b/src/system.js
@@ -1,6 +1,7 @@
 import './features/script-load.js';
 import './features/resolve.js';
 import './features/import-maps.js';
+import './features/depcache.js';
 import './features/worker-load.js';
 import './extras/global.js';
 import './extras/module-types.js';


### PR DESCRIPTION
When auto imports were added, the implementation ended up conflicting with depcache by changing the execution order.

This separates out the depcache code so it hooks instantiate after the script loader properly.