### PR TITLE
Fix auto import dynamic imports during loading

### DIFF
--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -31,7 +31,7 @@ systemJSPrototype.createScript = function (url) {
 };
 
 // Auto imports -> script tags can be inlined directly for load phase
-var lastAutoImportUrl, lastAutoImportDeps;
+var lastAutoImportUrl, lastAutoImportDeps, lastAutoImportAutoImport;
 var autoImportCandidates = {};
 var systemRegister = systemJSPrototype.register;
 systemJSPrototype.register = function (deps, declare) {
@@ -45,7 +45,7 @@ systemJSPrototype.register = function (deps, declare) {
       autoImportCandidates[url] = [deps, declare];
       // if this is already a System load, then the instantiate has already begun
       // so this re-import has no consequence
-      this.import(url);
+      lastAutoImportAutoImport = setTimeout(this.import, 0, url);
     }
   }
   else {
@@ -77,8 +77,10 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
       else {
         var register = loader.getRegister();
         // Clear any auto import registration for dynamic import scripts during load
-        if (register && register[0] === lastAutoImportDeps)
+        if (register && register[0] === lastAutoImportDeps) {
+          clearTimeout(lastAutoImportAutoImport);
           delete autoImportCandidates[lastAutoImportUrl];
+        }
         resolve(register);
       }
     });


### PR DESCRIPTION
This fixes the issue posted at https://github.com/systemjs/systemjs/issues/2243#issuecomment-688385205 that the code to ignore new dynamic imports when checking the auto import list during the loading phase was happening too late - after the new dynamic import with the auto import cache had already been checked.

This brings back the timeout method previously removed in https://github.com/systemjs/systemjs/pull/2225 with a slightly simpler approach.

It appears the script list is not a valid replacement for currentScript because of dynamic injection cases like this. In particular we inject the script into the head, so that document writes in the body will always be later resulting in dynamic imports being incorrectly assigned over the auto imports of body scripts that are currently at the document write position.

While it does on the surface seem a problem to have lost this invariant, as far as I can tell I think we are still on top of a safe foundation for this feature, based on the remaining (and now revised) assumptions of its implementation:
1. Any script which does a System.register during load that was not loaded by SystemJS is considered an auto import
2. Those scripts get their URL detected by being the last "script" element on the page, this means it holds true for all static scripts and document.write scripts.
3. This PR fixes up the detection of System.register injected scripts made by SystemJS itself to ensure they are comprehensively never treated as auto imports.
4. Any other type of dynamic injection is fine and does not interfere with the above process (and this is why we don't need to have a true currentScript polyfill and can get away with the lack of one in IE11) - because if they don't call System.register, they are effectively invisible to this process. And if they do call System.register, that is breaking the invariant of the assumptions of this implementation that all System.register scripts are either static auto imports or loaded via SystemJS itself.

It may be necessary to make a related change to the fetch loader in due course to support auto imports as well.