### PR TITLE
Deprecate transform and use default extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ The following [pluggable extras](dist/extras) can be dropped in with either the 
 * [AMD loading](dist/extras/amd.js) support (through `Window.define` which is created).
 * [Named exports](dist/extras/named-exports.js) convenience extension support for global and AMD module formats (`import { x } from './global.js'` instead of `import G from './global.js'; G.x`)
 * [Named register](dist/extras/named-register.js) supports `System.register('name', ...)` named bundles which can then be imported as `System.import('name')` (as well as AMD named define support)
-* [Transform loader](dist/extras/transform.js) support, using fetch and eval, supporting a hookable `loader.transform`
 * [Dynamic import maps](dist/extras/dynamic-import-maps.js) support. This is currently a _potential_ new standard [feature](https://github.com/guybedford/import-maps-extensions#lazy-loading-of-import-maps).
 
 The following extras are included in system.js loader by default, and can be added to the s.js loader for a smaller tailored footprint:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -116,11 +116,3 @@ This hook is provided by the [module types extra](./module-types.md).
 
 The default fetch implementation used by module types is simply `System.fetch = window.fetch` and can be hooked through the fetch hook, allowing for
 any custom request interception.
-
-#### transform(url, source) -> Promise<String>
-
-This hook is provided by the [transform extra](../dist/extras/transform.js).
-
-The default implementation is a pass-through transform that returns the fetched source.
-
-For an example of a transform see the [Babel plugin transform](https://github.com/systemjs/systemjs-transform-babel).

--- a/src/extras/transform.js
+++ b/src/extras/transform.js
@@ -2,6 +2,8 @@ import { errMsg } from '../err-msg.js';
 
 /*
  * Support for a "transform" loader interface
+ *
+ * Note: This extra is deprecated and will be removed in the next major.
  */
 (function (global) {
   var systemJSPrototype = global.System.constructor.prototype;

--- a/src/extras/use-default.js
+++ b/src/extras/use-default.js
@@ -1,6 +1,8 @@
 /*
  * Interop for AMD modules to return the direct AMD binding instead of a
  * `{ default: amdModule }` object from `System.import`
+ * 
+ * Note: This extra is deprecated and will be removed in the next major.
  */
 (function (global) {
   var systemJSPrototype = global.System.constructor.prototype;


### PR DESCRIPTION
This deprecates the transform extra and also includes a note in both the transform and use default extras that they are deprecated for the next major.