### PR TITLE
Inline named exports extra into core

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ _Loading CommonJS modules is not currently supported in this loader and likely w
 The following [pluggable extras](dist/extras) can be dropped in with either the s.js or system.js loader:
 
 * [AMD loading](dist/extras/amd.js) support (through `Window.define` which is created).
-* [Named exports](dist/extras/named-exports.js) convenience extension support for global and AMD module formats (`import { x } from './global.js'` instead of `import G from './global.js'; G.x`)
 * [Named register](dist/extras/named-register.js) supports `System.register('name', ...)` named bundles which can then be imported as `System.import('name')` (as well as AMD named define support)
 * [Dynamic import maps](dist/extras/dynamic-import-maps.js) support. This is currently a _potential_ new standard [feature](https://github.com/guybedford/import-maps-extensions#lazy-loading-of-import-maps).
 

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -58,6 +58,7 @@ import { errMsg } from '../err-msg.js';
             module.exports = amdResult;
           if (exports !== module.exports)
             _export('default', module.exports);
+          _export(module.exports);
         }
       };
     }];

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -56,9 +56,8 @@ import { errMsg } from '../err-msg.js';
           var amdResult = amdExec.apply(exports, depModules);
           if (amdResult !== undefined)
             module.exports = amdResult;
-          if (exports !== module.exports)
-            _export('default', module.exports);
           _export(module.exports);
+          _export('default', module.exports);
         }
       };
     }];

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -74,6 +74,7 @@
     return [[], function (_export) {
       return {
         execute: function () {
+          _export(globalExport);
           _export({ default: globalExport, __useDefault: true });
         }
       };

--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -1,5 +1,8 @@
 /*
  * Named exports support for legacy module formats in SystemJS 2.0
+ * 
+ * Note: This extra is deprecated as the behaviour is now the default in core,
+ *       so will be removed in the next major.
  */
 (function (global) {
   var systemJSPrototype = global.System.constructor.prototype;

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -97,7 +97,7 @@ export function getOrCreateLoad (loader, id, firstParentUrl) {
       // note if we have hoisted exports (including reexports)
       load.h = true;
       var changed = false;
-      if (typeof name !== 'object') {
+      if (typeof name === 'string') {
         if (!(name in ns) || ns[name] !== value) {
           ns[name] = value;
           changed = true;

--- a/test/browser/named-exports.js
+++ b/test/browser/named-exports.js
@@ -1,8 +1,6 @@
 suite('Named exports', function () {
   suiteSetup(function() {
-    return System.import('../../dist/extras/named-exports.js').then(function() {
-      System = new System.constructor();
-    });
+    return System.import('../../dist/extras/amd.js').then(function() {});
   });
 
   test('Loading an AMD module with named exports', function () {


### PR DESCRIPTION
Now that Node.js has effectively standardized on the shell model like the named exports extra in SystemJS for CommonJS representations, we can follow the same by default in SystemJS.

This inlines the named exports logic into the SystemJS AMD and global extras, and deprecates the separate extra.