### PR TITLE
Dispatch script loading error

### DIFF
--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -33,7 +33,22 @@ function processScripts () {
       script.sp = true;
       if (!script.src)
         return;
-      System.import(script.src.slice(0, 7) === 'import:' ? script.src.slice(7) : resolveUrl(script.src, baseUrl));
+      System.import(script.src.slice(0, 7) === 'import:' ? script.src.slice(7) : resolveUrl(script.src, baseUrl)).catch(function (e) {
+        // if there is a script load error, dispatch an "error" event
+        // on the script tag.
+        if (e.message.indexOf('https://git.io/JvFET#3') > -1) {
+          var event
+          // IE 11 throw when callin new Event()
+          try {
+            event = new Event('error')
+          }
+          catch(_) {
+            event = document.createEvent('error')
+          }
+          script.dispatchEvent(event)
+        }
+        return Promise.reject(e)
+      });
     }
     else if (script.type === 'systemjs-importmap') {
       script.sp = true;

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -37,17 +37,11 @@ function processScripts () {
         // if there is a script load error, dispatch an "error" event
         // on the script tag.
         if (e.message.indexOf('https://git.io/JvFET#3') > -1) {
-          var event
-          // IE 11 throw when callin new Event()
-          try {
-            event = new Event('error')
-          }
-          catch(_) {
-            event = document.createEvent('error')
-          }
-          script.dispatchEvent(event)
+          var event = document.createEvent('Event');
+          event.initEvent('error', false, false);
+          script.dispatchEvent(event);
         }
-        return Promise.reject(e)
+        return Promise.reject(e);
       });
     }
     else if (script.type === 'systemjs-importmap') {


### PR DESCRIPTION
This pull request is a proposal to fix https://github.com/systemjs/systemjs/issues/2271.

It dispatches an `error` event on script tags that are failing to load due to a network error.
It replicates the browser behaviour that consists into dispatching an `error` on script tag that are failing to load. 
With this change it becomes possible to detect a script load error by doing:

```html
<script id="main-script" type="systemjs-module" src="./main.js" />
<script type="text/javascript" async>
  const mainScript = document.querySelector('#main-script')
  mainScript.onerror = () => {
    alert('main script load error')
  }
</script>
```

## Browser compatibility

This pull requests uses `dispatchEvent`. I have checked the browser compatibility of these two apis to ensure it works for IE11. 

![image](https://user-images.githubusercontent.com/443639/98461633-0bbe9e80-21ae-11eb-9daa-2771fa1d12a9.png)

Screenshots taken from
- https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent#Browser_Compatibility
