### PR TITLE
Only add sourceURL if not present and remove Firefox workaround

### DIFF
--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -29,12 +29,6 @@ systemJSPrototype.instantiate = function (url, parent) {
     if (!contentType || !jsContentTypeRegEx.test(contentType))
       throw Error(errMsg(4, process.env.SYSTEM_PRODUCTION ? contentType : 'Unknown Content-Type "' + contentType + '", loading ' + url + (parent ? ' from ' + parent : '')));
     return res.text().then(function (source) {
-      var sourceMappingIndex = source.lastIndexOf('//# sourceMappingURL=');
-      if (sourceMappingIndex > -1) {
-        var sourceMappingEnd = source.indexOf('\n', sourceMappingIndex);
-        var sourceMapping = source.slice(sourceMappingIndex, sourceMappingEnd > -1 ? sourceMappingEnd : undefined);
-        source += '\n//# sourceMappingURL=' + resolveUrl(sourceMapping.slice(21), url);
-      }
       if (source.indexOf('//# sourceURL=') < 0)
         source += '\n//# sourceURL=' + url;
       (0, eval)(source);

--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -35,7 +35,8 @@ systemJSPrototype.instantiate = function (url, parent) {
         var sourceMapping = source.slice(sourceMappingIndex, sourceMappingEnd > -1 ? sourceMappingEnd : undefined);
         source += '\n//# sourceMappingURL=' + resolveUrl(sourceMapping.slice(21), url);
       }
-      source += '\n//# sourceURL=' + url;
+      if (source.indexOf('//# sourceURL=') < 0)
+        source += '\n//# sourceURL=' + url;
       (0, eval)(source);
       return loader.getRegister();
     });

--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -1,5 +1,4 @@
 import { errMsg } from '../err-msg.js';
-import { resolveUrl } from '../common.js';
 import { importMap } from '../features/import-maps.js';
 import { systemJSPrototype } from '../system-core.js';
 


### PR DESCRIPTION
This updates the previous fetch source mapping changes to ensure that the `sourceURL` is only added if it is not already there.

Eg in the Babel loader, we suffix sources with `!system` to distinguish from the original source.

This also removes the Firefox workaround that was added per https://github.com/guybedford/es-module-shims/pull/37 as it seems like this may have been fixed.