### PR TITLE
Breaking: change global loading to load first created global. Resolves #2272.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,27 @@ Type: `Function`
 
 Resolves a module specifier relative to an optional parent URL, returning the resolved URL.
 
+#### System.firstGlobalProp: boolean
+Type: `Boolean`
+
+Applies to the global loading extra.
+
+Setting `System.firstGlobalProp = true` will ensure that the global loading extra will always use
+the first new global defined as the global module value, and not the last new global defined.
+
+For example, if importing the module `global.js`:
+
+```js
+window.a = 'a';
+window.b = 'b';
+```
+
+`System.import('./global.js')` would usually `{ default: 'b' }`.
+
+Setting `System.firstGlobalProp = true` would ensure the above returns `{ default: 'a' }`.
+
+> Note: This will likely be the default in the next major release.
+
 ### Registry API (system.js only)
 
 > Note: The registry API is **not recommended** for standard module loading workflows. It is designed more for tooling built around SystemJS such as hot-reloading workflows. If you find yourself wanting to define a module, rather try to restructure your module architecture around standard module import loading principles and import maps (and the same goes for named System.register).

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -17,7 +17,7 @@
         continue;
       if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
         return p;
-      if (systemJSPrototype.firstGlobalProp && p === foundLastProp)
+      if (systemJSPrototype.firstGlobalProp && foundLastProp)
         return p;
       foundLastProp = p === lastGlobalProp;
       cnt++;

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -17,15 +17,13 @@
         continue;
       if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
         return p;
-      if (systemJSPrototype.firstGlobalProp) {
-        if (foundLastProp) {
-          lastGlobalProp = p;
-          result = result || p;
-        }
-      } else
-        result = foundLastProp ? p : result;
-
-      foundLastProp = foundLastProp || p === lastGlobalProp;
+      if (foundLastProp) {
+        lastGlobalProp = p;
+        result = systemJSPrototype.firstGlobalProp && result || p;
+      }
+      else {
+        foundLastProp = p === lastGlobalProp;
+      }
       cnt++;
     }
     return result;

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -17,11 +17,14 @@
         continue;
       if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
         return p;
-      if (foundLastProp && !shouldSkipProperty(p)) {
-        lastGlobalProp = p;
-        result = result || p;
-      }
-      foundLastProp = foundLastProp || p === lastGlobalProp;
+      if (systemJSPrototype.firstGlobalProp) {
+        if (foundLastProp) {
+          lastGlobalProp = p;
+          result = result || p;
+        }
+        foundLastProp = foundLastProp || p === lastGlobalProp;
+      } else
+        result = p === lastGlobalProp ? result : p;
       cnt++;
     }
     return result;

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -10,13 +10,16 @@
   var firstGlobalProp, secondGlobalProp, lastGlobalProp;
   function getGlobalProp () {
     var cnt = 0;
-    var lastProp;
+    var lastProp, foundLastProp;
     for (var p in global) {
       // do not check frames cause it could be removed during import
       if (shouldSkipProperty(p))
         continue;
       if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
         return p;
+      if (systemJSPrototype.firstGlobalProp && p === foundLastProp)
+        return p;
+      foundLastProp = p === lastGlobalProp;
       cnt++;
       lastProp = p;
     }

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -17,10 +17,10 @@
         continue;
       if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
         return p;
-      if (foundLastProp && !result)
-        result = p;
-      if (foundLastProp && !shouldSkipProperty(p))
+      if (foundLastProp && !shouldSkipProperty(p)) {
         lastGlobalProp = p;
+        result = result || p;
+      }
       foundLastProp = foundLastProp || p === lastGlobalProp;
       cnt++;
     }

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -10,21 +10,21 @@
   var firstGlobalProp, secondGlobalProp, lastGlobalProp;
   function getGlobalProp () {
     var cnt = 0;
-    var lastProp, foundLastProp;
+    var foundLastProp, result;
     for (var p in global) {
       // do not check frames cause it could be removed during import
       if (shouldSkipProperty(p))
         continue;
       if (cnt === 0 && p !== firstGlobalProp || cnt === 1 && p !== secondGlobalProp)
         return p;
-      if (systemJSPrototype.firstGlobalProp && foundLastProp)
-        return p;
+      if (foundLastProp && !result)
+        result = p;
+      if (foundLastProp && !shouldSkipProperty(p))
+        lastGlobalProp = p;
       foundLastProp = p === lastGlobalProp;
       cnt++;
-      lastProp = p;
     }
-    if (lastProp !== lastGlobalProp)
-      return lastProp;
+    return result;
   }
 
   function noteGlobalProps () {

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -22,9 +22,10 @@
           lastGlobalProp = p;
           result = result || p;
         }
-        foundLastProp = foundLastProp || p === lastGlobalProp;
       } else
-        result = p === lastGlobalProp ? result : p;
+        result = foundLastProp ? p : result;
+
+      foundLastProp = foundLastProp || p === lastGlobalProp;
       cnt++;
     }
     return result;

--- a/src/extras/global.js
+++ b/src/extras/global.js
@@ -21,7 +21,7 @@
         result = p;
       if (foundLastProp && !shouldSkipProperty(p))
         lastGlobalProp = p;
-      foundLastProp = p === lastGlobalProp;
+      foundLastProp = foundLastProp || p === lastGlobalProp;
       cnt++;
     }
     return result;

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -115,12 +115,14 @@ suite('SystemJS Standard Tests', function() {
   test('Global script loading', function () {
     return System.import('fixtures/global.js').then(function (m) {
       assert.ok(m.default);
-      assert.equal(m.default.v, '2.0..0');
+      assert.equal(m.default.some, 'thing');
     });
   });
 
-  test('Global script loading with multiple globals', function () {
+  test('firstGlobalProp option', function () {
+    Object.getPrototypeOf(System).firstGlobalProp = true;
     return System.import('fixtures/multiple-globals.js').then(function (m) {
+      delete Object.getPrototypeOf(System).firstGlobalProp;
       assert.ok(m.default);
       assert.equal(m.default.foo1, 'foo1');
     });

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -115,7 +115,14 @@ suite('SystemJS Standard Tests', function() {
   test('Global script loading', function () {
     return System.import('fixtures/global.js').then(function (m) {
       assert.ok(m.default);
-      assert.equal(m.default.some, 'thing');
+      assert.equal(m.default.v, '2.0..0');
+    });
+  });
+
+  test('Global script loading with multiple globals', function () {
+    return System.import('fixtures/multiple-globals.js').then(function (m) {
+      assert.ok(m.default);
+      assert.equal(m.default.foo1, 'foo1');
     });
   });
 

--- a/test/fixtures/browser/multiple-globals.js
+++ b/test/fixtures/browser/multiple-globals.js
@@ -1,0 +1,8 @@
+var MainExport = (function () {
+  window.otherGlobal = 'otherGlobal';
+  window.__devtools = true;
+
+  return {
+    foo1: 'foo1'
+  };
+})()


### PR DESCRIPTION
This adds a backwards-compatible option for altering the global loading extra to use the first created global variable from a module, instead of the last one. 

To use it:

```js
Object.getPrototypeOf(System).firstGlobalProp = true;
```

I've confirmed that loading the official Vue 3 vue.global.js file works with this enabled. Am happy to add tests if this is an acceptable direction to take the global loading extra.