### PR TITLE
Note about webpack 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ As of webpack@4.30.0, it is now possible to compile webpack bundles to System.re
 }
 ```
 
-If building code using the `System` global in Webpack, the following config is needed to avoid rewriting:
+If using webpack@<5, the following config is needed to avoid rewriting references to the global `System` variable:
 
 ```js
 {


### PR DESCRIPTION
I discovered that webpack 5 no longer rewrites `System.import()` by default.