### PR TITLE
Fix deleting modules after link failure. Resolves #2286.

### DIFF
--- a/src/system-core.js
+++ b/src/system-core.js
@@ -156,6 +156,13 @@ export function getOrCreateLoad (loader, id, firstParentUrl) {
             if (depLoad.h || !depLoad.I)
               setter(depLoad.n);
           }
+
+          if (depLoad.L)
+            // https://github.com/systemjs/systemjs/issues/2286
+            depLoad.L.catch(function (err) {
+              load.e = null;
+            });
+
           return depLoad;
         });
       })

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -20,7 +20,6 @@ export { systemJSPrototype, REGISTRY }
 
 var toStringTag = hasSymbol && Symbol.toStringTag;
 var REGISTRY = hasSymbol ? Symbol() : '@';
-var emptyFunction = function () {};
 
 function SystemJS () {
   this[REGISTRY] = {};
@@ -168,6 +167,7 @@ export function getOrCreateLoad (loader, id, firstParentUrl) {
       load.d = depLoads;
     });
   });
+  linkPromise.catch(function () {});
 
   // Capital letter = a promise function
   return load = loader[REGISTRY][id] = {

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -156,10 +156,6 @@ export function getOrCreateLoad (loader, id, firstParentUrl) {
               setter(depLoad.n);
           }
           return depLoad;
-        }, function (err) {
-          load.e = null;
-          if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, false);
-          throw err;
         });
       });
     }))
@@ -214,12 +210,14 @@ function instantiateAll (loader, load, loaded) {
     .then(function () {
       return Promise.all(load.d.map(function (dep) {
         return instantiateAll(loader, dep, loaded);
-      }))
-      .catch(function (err) {
-        load.e = null;
-        if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, false);
+      }));
+    })
+    .catch(function (err) {
+      if (load.er)
         throw err;
-      });
+      load.e = null;
+      if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, false);
+      throw err;
     });
   }
 }

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -303,6 +303,20 @@ suite('SystemJS Standard Tests', function() {
     });
   });
 
+  // https://github.com/systemjs/systemjs/issues/2286
+  test('should allow deletion of modules that failed to instantiate', function () {
+    return System.import('fixtures/link-error.js').then(
+      function () {
+        throw Error('Link error expected');
+      },
+      function () {
+        assert.ok(System.delete(System.resolve('fixtures/link-error.js')));
+        assert.ok(System.delete(System.resolve('fixtures/link-error-child.js')));
+        assert.ok(System.delete(System.resolve('fixtures/not-found.js')));
+      }
+    );
+  });
+
   var isIE11 = typeof navigator !== 'undefined' && navigator.userAgent.indexOf('Trident') !== -1;
 
   function isCSSStyleSheet(obj) {

--- a/test/fixtures/browser/link-error-child.js
+++ b/test/fixtures/browser/link-error-child.js
@@ -1,0 +1,6 @@
+System.register(['./not-found.js'], function () {
+  return {
+    execute: function () {
+    }
+  };
+});

--- a/test/fixtures/browser/link-error.js
+++ b/test/fixtures/browser/link-error.js
@@ -1,0 +1,6 @@
+System.register(['./link-error-child.js'], function () {
+  return {
+    execute: function () {
+    }
+  };
+});


### PR DESCRIPTION
See #2286. Note that this bug only occurs if the link failure occurs in a dependency, instead of directly on the top level load.