### PR TITLE
Allow deletion of uninstantiated modules whose top level parent import finished. Resolves #2286.

### DIFF
--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -67,7 +67,7 @@ systemJSPrototype.delete = function (id) {
   var load = registry[id];
   // in future we can support load.E case by failing load first
   // but that will require TLA callbacks to be implemented
-  if (!load || load.E)
+  if (!load || (load.p || load).e !== null || load.E)
     return false;
 
   var importerSetters = load.i;

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -67,7 +67,7 @@ systemJSPrototype.delete = function (id) {
   var load = registry[id];
   // in future we can support load.E case by failing load first
   // but that will require TLA callbacks to be implemented
-  if (!load || (load.p || load).e !== null || load.E)
+  if (!load || load.p.e !== null || load.E)
     return false;
 
   var importerSetters = load.i;

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -67,7 +67,7 @@ systemJSPrototype.delete = function (id) {
   var load = registry[id];
   // in future we can support load.E case by failing load first
   // but that will require TLA callbacks to be implemented
-  if (!load || load.e !== null || load.E)
+  if (!load || load.E)
     return false;
 
   var importerSetters = load.i;

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -67,7 +67,7 @@ systemJSPrototype.delete = function (id) {
   var load = registry[id];
   // in future we can support load.E case by failing load first
   // but that will require TLA callbacks to be implemented
-  if (!load || load.p.e !== null || load.E)
+  if (!load || (load.p && load.p.e !== null) || load.E)
     return false;
 
   var importerSetters = load.i;

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -199,8 +199,7 @@ export function getOrCreateLoad (loader, id, firstParentUrl) {
     // Promise for top-level completion
     C: undefined,
 
-    // parent importer
-    // on error, this is cleared
+    // parent instantiator / executor
     p: undefined
   };
 }
@@ -211,7 +210,8 @@ function instantiateAll (loader, load, parent, loaded) {
     // load.L may be undefined for already-instantiated
     return Promise.resolve(load.L)
     .then(function () {
-      load.p = parent;
+      if (load.e !== null)
+        load.p = parent;
       return Promise.all(load.d.map(function (dep) {
         return instantiateAll(loader, dep, parent, loaded);
       }));

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -210,7 +210,7 @@ function instantiateAll (loader, load, parent, loaded) {
     // load.L may be undefined for already-instantiated
     return Promise.resolve(load.L)
     .then(function () {
-      if (load.e !== null)
+      if (load.e !== null && (!load.p || load.p.e === null))
         load.p = parent;
       return Promise.all(load.d.map(function (dep) {
         return instantiateAll(loader, dep, parent, loaded);

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -210,7 +210,7 @@ function instantiateAll (loader, load, parent, loaded) {
     // load.L may be undefined for already-instantiated
     return Promise.resolve(load.L)
     .then(function () {
-      if (load.e !== null && (!load.p || load.p.e === null))
+      if (!load.p || load.p.e === null)
         load.p = parent;
       return Promise.all(load.d.map(function (dep) {
         return instantiateAll(loader, dep, parent, loaded);

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -199,7 +199,10 @@ export function getOrCreateLoad (loader, id, firstParentUrl) {
     // On execution, L, I, E cleared
 
     // Promise for top-level completion
-    C: undefined
+    C: undefined,
+
+    // load for firstParent
+    p: loader[REGISTRY][firstParentUrl]
   };
 }
 

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -229,7 +229,7 @@ function instantiateAll (loader, load, parent, loaded) {
 function topLevelLoad (loader, load) {
   return load.C = instantiateAll(loader, load, load, {})
   .then(function () {
-    return postOrderExec(loader, load, load, {});
+    return postOrderExec(loader, load, {});
   })
   .then(function () {
     return load.n;

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -313,11 +313,7 @@ suite('SystemJS Standard Tests', function() {
         assert.ok(System.delete(System.resolve('fixtures/link-error.js')));
         assert.ok(System.delete(System.resolve('fixtures/link-error-child.js')));
         assert.ok(System.delete(System.resolve('fixtures/not-found.js')));
-        assert.ok(System.has(System.resolve('fixtures/link-error-child2.js')));
-        return System.import('fixtures/link-error-child2.js').then(function () {
-          assert.ok(System.get(System.resolve('fixtures/link-error-child2.js')).default);
-          assert.ok(System.delete(System.resolve('fixtures/link-error-child2.js')));
-        })
+        assert.ok(System.delete(System.resolve('fixtures/link-error-child2.js')));
       }
     );
   });

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -313,6 +313,7 @@ suite('SystemJS Standard Tests', function() {
         assert.ok(System.delete(System.resolve('fixtures/link-error.js')));
         assert.ok(System.delete(System.resolve('fixtures/link-error-child.js')));
         assert.ok(System.delete(System.resolve('fixtures/not-found.js')));
+        assert.ok(System.delete(System.resolve('fixtures/link-error-child2.js')));
       }
     );
   });

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -313,6 +313,8 @@ suite('SystemJS Standard Tests', function() {
         assert.ok(System.delete(System.resolve('fixtures/link-error.js')));
         assert.ok(System.delete(System.resolve('fixtures/link-error-child.js')));
         assert.ok(System.delete(System.resolve('fixtures/not-found.js')));
+        assert.ok(System.has(System.resolve('fixtures/link-error-child2.js')));
+        assert.ok(System.get(System.resolve('fixtures/link-error-child2.js')).default);
         assert.ok(System.delete(System.resolve('fixtures/link-error-child2.js')));
       }
     );

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -314,8 +314,10 @@ suite('SystemJS Standard Tests', function() {
         assert.ok(System.delete(System.resolve('fixtures/link-error-child.js')));
         assert.ok(System.delete(System.resolve('fixtures/not-found.js')));
         assert.ok(System.has(System.resolve('fixtures/link-error-child2.js')));
-        assert.ok(System.get(System.resolve('fixtures/link-error-child2.js')).default);
-        assert.ok(System.delete(System.resolve('fixtures/link-error-child2.js')));
+        return System.import('fixtures/link-error-child2.js').then(function () {
+          assert.ok(System.get(System.resolve('fixtures/link-error-child2.js')).default);
+          assert.ok(System.delete(System.resolve('fixtures/link-error-child2.js')));
+        })
       }
     );
   });

--- a/test/fixtures/browser/link-error-child2.js
+++ b/test/fixtures/browser/link-error-child2.js
@@ -1,6 +1,7 @@
-System.register([], function () {
+System.register([], function (_export) {
   return {
     execute: function () {
+      _export('default', 'link-error-child2 instantiated successfully');
     }
   };
 });

--- a/test/fixtures/browser/link-error-child2.js
+++ b/test/fixtures/browser/link-error-child2.js
@@ -1,0 +1,6 @@
+System.register([], function () {
+  return {
+    execute: function () {
+    }
+  };
+});

--- a/test/fixtures/browser/link-error.js
+++ b/test/fixtures/browser/link-error.js
@@ -1,4 +1,4 @@
-System.register(['./link-error-child.js'], function () {
+System.register(['./link-error-child.js', './link-error-child2.js'], function () {
   return {
     execute: function () {
     }


### PR DESCRIPTION
See https://github.com/systemjs/systemjs/issues/2286#issuecomment-746240996. This test confirms that there is currently a bug. I hope to push a fix in a subsequent commit.