### PR TITLE
Export package.json so tools can more easily access meta data

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
       "default": "./dist/system.min.js"
     },
     "./s.js": "./dist/s.min.js",
+    "./package.json": "./package.json",
     "./dist/": "./dist/"
   },
   "description": "Dynamic ES module loader",


### PR DESCRIPTION
I'd love if I could use the traditional

```bash
nodejs -p "require.resolve('systemjs/package.json')"
```

to find the module root directory.

with current master:

```text
    throw e;
    ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /tmp/sandbox/node_modules/systemjs/package.json imported from …
```

with my branch:

```text
/tmp/sandbox/node_modules/systemjs/package.json
```