### PR TITLE
Onerror Callback Support for Errors Fetching External Import Map 

### DIFF
--- a/docs/import-maps.md
+++ b/docs/import-maps.md
@@ -204,7 +204,7 @@ Previous versions of the import maps spec had support for multiple import maps i
 
 For handling errors when fetching external import maps (specifically for [SystemJS Warning #W4](https://github.com/systemjs/systemjs/blob/master/docs/errors.md#w4)), we can use the `onerror` attribute in the `<script type="systemjs-importmap">` tag.
 
-In the `onerror` attribute, we can specify a callback function that will be executed when there is an error.
+In the `onerror` attribute, specify a script to execute when there is an error.
 
 ```html
 <script type="systemjs-importmap" onerror="handleError()" src="unable-to-reach/importmap.json"></script>
@@ -214,6 +214,9 @@ In the `onerror` attribute, we can specify a callback function that will be exec
     // Put error handling/retry logic here.
   }
 </script>
+
+<!-- Can also have inline definition for error handling script -->
+<script type="systemjs-importmap" onerror='console.log("Running onerror script")' src="unable-to-reach/importmap.json"></script>
 ```
 
 #### Spec and Implementation Feedback

--- a/docs/import-maps.md
+++ b/docs/import-maps.md
@@ -200,6 +200,20 @@ Any existing mappings are replaced, although in future this may be an error.
 
 Previous versions of the import maps spec had support for multiple import maps in a single web page ([explanation](https://github.com/WICG/import-maps/issues/199)). SystemJS added support for multiple import maps during that time and has decided to keep support for multiple import maps as an experimental feature ([discussion](https://github.com/systemjs/systemjs/issues/2095)). Note that the Chrome implementation of import maps does not yet allow for multiple maps, and use of multiple import maps within SystemJS should be considered experimental and subject to change.
 
+### Handling Import Map Errors
+
+For handling errors fetching external import maps (specifically for [SystemJS Warning #W4](https://github.com/systemjs/systemjs/blob/master/docs/errors.md#w4)), we can specify a callback function with the `onerror` attribute in the `<script type="systemjs-importmap">` tag.
+
+```html
+<script type="systemjs-importmap" src="unable-to-reach/importmap.json" onerror="handleError()"></script>
+
+<script type="text/javascript">
+  function handleError() {
+    // Put error handling/retry logic here.
+  }
+</script>
+```
+
 #### Spec and Implementation Feedback
 
 Part of the benefit of giving users a working version of an early spec is being able to get real user feedback on the [import maps specification](https://github.com/wicg/import-maps/blob/master/spec.md).

--- a/docs/import-maps.md
+++ b/docs/import-maps.md
@@ -202,10 +202,12 @@ Previous versions of the import maps spec had support for multiple import maps i
 
 ### Handling Import Map Errors
 
-For handling errors fetching external import maps (specifically for [SystemJS Warning #W4](https://github.com/systemjs/systemjs/blob/master/docs/errors.md#w4)), we can specify a callback function with the `onerror` attribute in the `<script type="systemjs-importmap">` tag.
+For handling errors when fetching external import maps (specifically for [SystemJS Warning #W4](https://github.com/systemjs/systemjs/blob/master/docs/errors.md#w4)), we can use the `onerror` attribute in the `<script type="systemjs-importmap">` tag.
+
+In the `onerror` attribute, we can specify a callback function that will be executed when there is an error.
 
 ```html
-<script type="systemjs-importmap" src="unable-to-reach/importmap.json" onerror="handleError()"></script>
+<script type="systemjs-importmap" onerror="handleError()" src="unable-to-reach/importmap.json"></script>
 
 <script type="text/javascript">
   function handleError() {

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -53,6 +53,13 @@ function processScripts () {
       }).catch(function (err) {
         err.message = errMsg('W4', process.env.SYSTEM_PRODUCTION ? script.src : 'Error fetching systemjs-import map ' + script.src) + '\n' + err.message;
         console.warn(err);
+        if (typeof script.onerror === 'function') {
+          try {
+            script.onerror();
+          } catch(callbackErr) {
+            console.error(callbackErr);
+          }
+        }
         return '{}';
       }) : script.innerHTML;
       importMapPromise = importMapPromise.then(function () {

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -54,12 +54,7 @@ function processScripts () {
         err.message = errMsg('W4', process.env.SYSTEM_PRODUCTION ? script.src : 'Error fetching systemjs-import map ' + script.src) + '\n' + err.message;
         console.warn(err);
         if (typeof script.onerror === 'function') {
-          try {
             script.onerror();
-          } catch(callbackErr) {
-            callbackErr.message = 'Error during onerror script for systemjs-importmap: ' + script.src + '\n' + callbackErr.message;
-            console.error(callbackErr);
-          }
         }
         return '{}';
       }) : script.innerHTML;

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -57,6 +57,7 @@ function processScripts () {
           try {
             script.onerror();
           } catch(callbackErr) {
+            callbackErr.message = 'Error during onerror callback function of systemjs-importmap script: ' + script.src + '\n' + callbackErr.message;
             console.error(callbackErr);
           }
         }

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -57,7 +57,7 @@ function processScripts () {
           try {
             script.onerror();
           } catch(callbackErr) {
-            callbackErr.message = 'Error during onerror callback function of systemjs-importmap script: ' + script.src + '\n' + callbackErr.message;
+            callbackErr.message = 'Error during onerror script for systemjs-importmap: ' + script.src + '\n' + callbackErr.message;
             console.error(callbackErr);
           }
         }

--- a/test/test.html
+++ b/test/test.html
@@ -29,7 +29,6 @@
 	<script type="systemjs-importmap" src="https://hostname.invalid/importmap.json"></script>
 	<script type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json"></script>
 	<script type="systemjs-importmap" onerror="retryImportMap()" src="fixtures/browser/importmap-invalid.json"></script>
-	<script type="systemjs-importmap" onerror="callbackDNE()" src="fixtures/browser/importmap-invalid.json"></script>
 	<script type="text/javascript">
 		function retryImportMap() {
 			document.write('<scr'+'ipt type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json"></sc'+'ript>');

--- a/test/test.html
+++ b/test/test.html
@@ -28,8 +28,8 @@
 
 	<script type="systemjs-importmap" src="https://hostname.invalid/importmap.json"></script>
 	<script type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json"></script>
-	<script type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json" onerror="retryImportMap()"></script>
-	<script type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json" onerror="callbackDNE()"></script>
+	<script type="systemjs-importmap" onerror="retryImportMap()" src="fixtures/browser/importmap-invalid.json"></script>
+	<script type="systemjs-importmap" onerror="callbackDNE()" src="fixtures/browser/importmap-invalid.json"></script>
 	<script type="text/javascript">
 		function retryImportMap() {
 			document.write('<scr'+'ipt type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json"></sc'+'ript>');

--- a/test/test.html
+++ b/test/test.html
@@ -28,6 +28,13 @@
 
 	<script type="systemjs-importmap" src="https://hostname.invalid/importmap.json"></script>
 	<script type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json"></script>
+	<script type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json" onerror="retryImportMap()"></script>
+	<script type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json" onerror="callbackDNE()"></script>
+	<script type="text/javascript">
+		function retryImportMap() {
+			document.write('<scr'+'ipt type="systemjs-importmap" src="fixtures/browser/importmap-invalid.json"></sc'+'ript>');
+		}
+	</script>
 	<script type="systemjs-importmap" src="fixtures/browser/importmap.json" integrity="sha384-+t/f9i0vQYwxmcczlIpgCCTQz2mA1sMGYGErJ4fZb/Lcx/yYrFSiedO0XpSIX8oX"></script>
 	<script type="systemjs-module" src="/test/fixtures/browser/systemjs-module-early.js"></script>
 	<script src="../dist/system.js"></script>


### PR DESCRIPTION
Hi,

These changes are for being able to execute custom error handling logic when fetching external import maps. On event of this [error](https://github.com/systemjs/systemjs/blob/master/docs/errors.md#w4), if defined, the script in the `onerror` attribute will be executed.

```html
<script type="systemjs-importmap" onerror="handleError()" src="unable-to-reach/importmap.json"></script>
```

This is addressing this [issue](https://github.com/systemjs/systemjs/issues/2312).