### PR TITLE
Fix the relative path problem of CSS url() in CSSStyleSheet()

### DIFF
--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -35,7 +35,7 @@ import { resolveUrl } from '../common.js';
       if (cssContentType.test(contentType))
         return res.text()
         .then(function (source) {
-          source = source.replace(/url\(\s*(["'])?((?:\\.|[^"')\\])+)\1\s*\)/g, function (match, quotes, relUrl) {
+          source = source.replace(/url\(\s*(["'])?((?:\\.|[^\s,"'()\\])+)\1\s*\)/g, function (match, quotes, relUrl) {
             return 'url(' + quotes + resolveUrl(relUrl, url) + quotes + ')';
           });
           return new Response(new Blob([

--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -33,7 +33,7 @@
       if (cssContentType.test(contentType))
         return res.text()
         .then(function (source) {
-          source = source.replace(/url\(([ '"]?)([^:]*?)\1\)/g, function (match, quotes, id) {
+          source = source.replace(/url\(\s*?(["']??)((?:\\.|[^\s:"'])+?)\1\s*?\)/g, function (match, quotes, id) {
             return 'url(' + quotes + systemJSPrototype.resolve(id, url) + quotes + ')';
           });
           return new Response(new Blob([

--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -1,3 +1,5 @@
+import { resolveUrl } from '../common.js';
+
 /*
  * Loads JSON, CSS, Wasm module types based on file extension
  * filters and content type verifications
@@ -33,8 +35,8 @@
       if (cssContentType.test(contentType))
         return res.text()
         .then(function (source) {
-          source = source.replace(/url\(\s*?(["']??)((?:\\.|[^\s:"'])+?)\1\s*?\)/g, function (match, quotes, id) {
-            return 'url(' + quotes + systemJSPrototype.resolve(id, url) + quotes + ')';
+          source = source.replace(/url\(\s*?(["']??)((?:\\.|[^\s:"'])+?)\1\s*?\)/g, function (match, quotes, relUrl) {
+            return 'url(' + quotes + resolveUrl(relUrl, url) + quotes + ')';
           });
           return new Response(new Blob([
             'System.register([],function(e){return{execute:function(){var s=new CSSStyleSheet();s.replaceSync(' + JSON.stringify(source) + ');e("default",s)}}})'

--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -35,8 +35,8 @@ import { resolveUrl } from '../common.js';
       if (cssContentType.test(contentType))
         return res.text()
         .then(function (source) {
-          source = source.replace(/url\(\s*(["'])?((?:\\.|[^\s,"'()\\])+)\1\s*\)/g, function (match, quotes, relUrl) {
-            return 'url(' + quotes + resolveUrl(relUrl, url) + quotes + ')';
+          source = source.replace(/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g, function (match, quotes, relUrl1, relUrl2) {
+            return 'url(' + quotes + resolveUrl(relUrl1 || relUrl2, url) + quotes + ')';
           });
           return new Response(new Blob([
             'System.register([],function(e){return{execute:function(){var s=new CSSStyleSheet();s.replaceSync(' + JSON.stringify(source) + ');e("default",s)}}})'

--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -35,7 +35,7 @@ import { resolveUrl } from '../common.js';
       if (cssContentType.test(contentType))
         return res.text()
         .then(function (source) {
-          source = source.replace(/url\(\s*?(["']??)((?:\\.|[^\s:"'])+?)\1\s*?\)/g, function (match, quotes, relUrl) {
+          source = source.replace(/url\(\s*(["'])?((?:\\.|[^"')\\])+)\1\s*\)/g, function (match, quotes, relUrl) {
             return 'url(' + quotes + resolveUrl(relUrl, url) + quotes + ')';
           });
           return new Response(new Blob([

--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -33,6 +33,9 @@
       if (cssContentType.test(contentType))
         return res.text()
         .then(function (source) {
+          source = source.replace(/url\(([ '"]?)([^:]*?)\1\)/g, function (match, quotes, id) {
+            return 'url(' + quotes + systemJSPrototype.resolve(id, url) + quotes + ')';
+          });
           return new Response(new Blob([
             'System.register([],function(e){return{execute:function(){var s=new CSSStyleSheet();s.replaceSync(' + JSON.stringify(source) + ');e("default",s)}}})'
           ], {


### PR DESCRIPTION
Hello, thanks for SystemJS, it helped me a lot. However, while using CSS Modules, I found a problem with the relative path of CSS url() in CSSStyleSheet(). The CSS specification states that the partial URLs are interpreted relative to the source of the style sheet, not relative to the document. But the Constructable Stylesheet Objects draft states that the partial URLs are interpreted relative to the document. Thus causing the resource to fail to load. I tried to solve this problem by replacing all the relative paths with absolute one, which might help others. 

[https://www.w3.org/TR/CSS1/#url](https://www.w3.org/TR/CSS1/#url)
<img width="763" alt="css-url" src="https://user-images.githubusercontent.com/2867188/116518647-18bd7e80-a903-11eb-84fc-eaf2be33a21d.png">

[https://wicg.github.io/construct-stylesheets/#dom-cssstylesheet-cssstylesheet](https://wicg.github.io/construct-stylesheets/#dom-cssstylesheet-cssstylesheet)
<img width="763" alt="cssstylesheet" src="https://user-images.githubusercontent.com/2867188/116519882-959d2800-a904-11eb-9978-a9069e92beaa.png">
