### PR TITLE
Fix named-register.js - omit name from register call. Resolves #2293.

### DIFF
--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -35,7 +35,7 @@
         firstNamedDefine = null;
       });
     }
-    return register.apply(deps, declare);
+    return register.apply(this, [deps, declare]);
   };
 
   var resolve = systemJSPrototype.resolve;

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -35,7 +35,7 @@
         firstNamedDefine = null;
       });
     }
-    return register.apply(this, arguments);
+    return register.apply(deps, declare);
   };
 
   var resolve = systemJSPrototype.resolve;


### PR DESCRIPTION
See https://github.com/systemjs/systemjs/issues/2327#issuecomment-831756226 and #2293. cc @anhallbe who found the problem.

System core expects to never be called with the string name as the first argument, but named-register does so. The reason the tests pass and named-register works for some people is that named-register overrides `getRegister` to retrieve from `registerRegistry` for named registers. However, when that doesn't happen, the `lastRegister` in system core is just incorrect!