### PR TITLE
Do not export null as module.exports in amd.js. Resolves #2332.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -57,8 +57,7 @@ import { errMsg } from '../err-msg.js';
           if (amdResult !== undefined)
             module.exports = amdResult;
           // https://github.com/systemjs/systemjs/issues/2332
-          if (module.exports !== null)
-            _export(module.exports);
+          _export(module.exports);
           _export('default', module.exports);
         }
       };

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -56,6 +56,7 @@ import { errMsg } from '../err-msg.js';
           var amdResult = amdExec.apply(exports, depModules);
           if (amdResult !== undefined)
             module.exports = amdResult;
+          // https://github.com/systemjs/systemjs/issues/2332
           if (module.exports !== null)
             _export(module.exports);
           _export('default', module.exports);

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -56,7 +56,8 @@ import { errMsg } from '../err-msg.js';
           var amdResult = amdExec.apply(exports, depModules);
           if (amdResult !== undefined)
             module.exports = amdResult;
-          _export(module.exports);
+          if (module.exports !== null)
+            _export(module.exports);
           _export('default', module.exports);
         }
       };

--- a/src/extras/named-exports.js
+++ b/src/extras/named-exports.js
@@ -30,7 +30,7 @@
       // hook the _export function to note the default export
       var defaultExport, hasDefaultExport = false;
       var declaration = registerDeclare.call(this, function (name, value) {
-        if (typeof name === 'object' && name.__useDefault)
+        if (typeof name === 'object' && name && name.__useDefault)
           defaultExport = name.default, hasDefaultExport = true;
         else if (name === 'default')
           defaultExport = value;

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -112,7 +112,7 @@ export function getOrCreateLoad (loader, id, firstParentUrl) {
           }
         }
 
-        if (name.__esModule) {
+        if (name && name.__esModule) {
           ns.__esModule = name.__esModule;
         }
       }

--- a/test/browser/amd.js
+++ b/test/browser/amd.js
@@ -82,4 +82,11 @@ suite('AMD tests', function () {
       assert.equal(m.default, false);
     });
   });
+
+  // https://github.com/systemjs/systemjs/issues/2332
+  test('loading an AMD module that sets module.exports to null', function () {
+    return System.import('fixtures/amd-null-module.js').then(function (m) {
+      assert.equal(m.default, null);
+    });
+  });
 });

--- a/test/fixtures/browser/amd-null-module.js
+++ b/test/fixtures/browser/amd-null-module.js
@@ -1,0 +1,3 @@
+define([], function () {
+  return null;
+});


### PR DESCRIPTION
See #2332 - both system-core and named-exports do not work if `_export(null)` occurs, as it appears to be invalid. However, amd.js would do this as explained in #2332. My fix here is specific only to null, rather than an object check + null check, since it's valid to loop over the keys of functions for re-exporting.