### PR TITLE
Refactor amd.js to only call System.register. Resolves #2331.

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -4,17 +4,9 @@ import { errMsg } from '../err-msg.js';
  * Support for AMD loading
  */
 (function (global) {
-  var systemPrototype = global.System.constructor.prototype;
-
-  var emptyInstantiation = [[], function () { return {} }];
-
   function unsupportedRequire () {
     throw Error(process.env.SYSTEM_PRODUCTION ? errMsg(5) : errMsg(5, 'AMD require not supported.'));
   }
-
-  var tmpRegister, firstNamedDefine;
-
-  function emptyFn () {}
 
   var requireExportsModule = ['require', 'exports', 'module'];
 
@@ -70,104 +62,46 @@ import { errMsg } from '../err-msg.js';
     }
   }
 
-  // hook System.register to know the last declaration binding
-  var lastRegisterDeclare;
-  var systemRegister = systemPrototype.register;
-  systemPrototype.register = function (name, deps, declare) {
-    lastRegisterDeclare = typeof name === 'string' ? declare : deps;
-    systemRegister.apply(this, arguments);
-  };
+  global.define = function (arg1, arg2, arg3) {
+    var isNamedRegister = typeof arg1 === 'string'
+    var name = isNamedRegister ? arg1 : null;
+    var depArg = isNamedRegister ? arg2 : arg1
+    var execArg = isNamedRegister ? arg3 : arg2
 
-  var instantiate = systemPrototype.instantiate;
-  systemPrototype.instantiate = function() {
-    // Reset "currently executing script"
-    amdDefineDeps = null;
-    return instantiate.apply(this, arguments);
-  };
+    // The System.register(deps, exec) arguments
+    var deps, exec
 
-  var getRegister = systemPrototype.getRegister;
-  systemPrototype.getRegister = function () {
-    if (tmpRegister)
-      return tmpRegister;
-
-    var _firstNamedDefine = firstNamedDefine;
-    firstNamedDefine = null;
-
-    var register = getRegister.call(this);
-    // if its an actual System.register leave it
-    if (register && register[1] === lastRegisterDeclare)
-      return register;
-
-    var _amdDefineDeps = amdDefineDeps;
-    amdDefineDeps = null;
-
-    // If the script registered a named module, return that module instead of re-instantiating it.
-    if (_firstNamedDefine)
-      return _firstNamedDefine;
-
-    // otherwise AMD takes priority
-    // no registration -> attempt AMD detection
-    if (!_amdDefineDeps)
-      return register || emptyInstantiation;
-
-    return createAMDRegister(_amdDefineDeps, amdDefineExec);
-  };
-  var amdDefineDeps, amdDefineExec;
-  global.define = function (name, deps, execute) {
-    var depsAndExec;
-    // define('', [], function () {})
-    if (typeof name === 'string') {
-      depsAndExec = getDepsAndExec(deps, execute);
-      if (amdDefineDeps) {
-        if (!System.registerRegistry) {
-          throw Error(process.env.SYSTEM_PRODUCTION ? errMsg(6) : errMsg(6, 'Include the named register extension for SystemJS named AMD support.'));
-        }
-        addToRegisterRegistry(name, createAMDRegister(depsAndExec[0], depsAndExec[1]));
-        amdDefineDeps = [];
-        amdDefineExec = emptyFn;
-        return;
-      }
-      else {
-        if (System.registerRegistry)
-          addToRegisterRegistry(name, createAMDRegister([].concat(depsAndExec[0]), depsAndExec[1]));
-        name = deps;
-        deps = execute;
-      }
-    }
-    depsAndExec = getDepsAndExec(name, deps);
-    amdDefineDeps = depsAndExec[0];
-    amdDefineExec = depsAndExec[1];
-  };
-  global.define.amd = {};
-
-  function getDepsAndExec(arg1, arg2) {
     // define([], function () {})
-    if (arg1 instanceof Array) {
-      return [arg1, arg2];
+    if (Array.isArray(depArg)) {
+      deps = depArg;
+      exec = execArg
     }
     // define({})
-    else if (typeof arg1 === 'object') {
-      return [[], function () { return arg1 }];
+    else if (typeof depArg === 'object') {
+      deps = []
+      exec = function () { return depArg }
     }
     // define(function () {})
-    else if (typeof arg1 === 'function') {
-      return [requireExportsModule, arg1];
-    }
-  }
-
-  function addToRegisterRegistry(name, define) {
-    if (!firstNamedDefine) {
-      firstNamedDefine = define;
-      Promise.resolve().then(function () {
-        firstNamedDefine = null;
-      });
+    else if (typeof depArg === 'function') {
+      deps = requireExportsModule
+      exec = depArg;
+    } else {
+      // TODO: create new error number and documentation for invalid call to define()
     }
 
-    // We must call System.getRegister() here to give other extras, such as the named-exports extra,
-    // a chance to modify the define before it's put into the registerRegistry.
-    // See https://github.com/systemjs/systemjs/issues/2073
-    tmpRegister = define;
-    System.registerRegistry[name] = System.getRegister();
-    tmpRegister = null;
-  }
+    var amdRegister = createAMDRegister(deps, exec)
+
+    if (isNamedRegister) {
+      if (System.registerRegistry) {
+        System.registerRegistry[name] = amdRegister;
+        System.register(name, amdRegister[0], amdRegister[1])
+      } else {
+        // TODO: create new warning number and documentation for using named define without named-register extra
+        System.register(amdRegister[0], amdRegister[1])
+      }
+    } else {
+      System.register(amdRegister[0], amdRegister[1])
+    }
+  };
+  global.define.amd = {};
 })(typeof self !== 'undefined' ? self : global);

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -95,13 +95,11 @@ import { errMsg } from '../err-msg.js';
       if (System.registerRegistry) {
         System.registerRegistry[name] = amdRegister;
         System.register(name, amdRegister[0], amdRegister[1]);
-      } else {
+      } else
         // TODO: create new warning number and documentation for using named define without named-register extra
         System.register(amdRegister[0], amdRegister[1]);
-      }
-    } else {
+    } else
       System.register(amdRegister[0], amdRegister[1]);
-    }
   };
   global.define.amd = {};
 })(typeof self !== 'undefined' ? self : global);

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -86,7 +86,7 @@ import { errMsg } from '../err-msg.js';
       deps = requireExportsModule;
       exec = depArg;
     } else {
-      // TODO: create new error number and documentation for invalid call to define()
+      throw Error(process.env.SYSTEM_PRODUCTION ? errMsg(9) : errMsg(9, 'Invalid call to AMD define()'));
     }
 
     var amdRegister = createAMDRegister(deps, exec);
@@ -96,6 +96,7 @@ import { errMsg } from '../err-msg.js';
         System.registerRegistry[name] = amdRegister;
         System.register(name, amdRegister[0], amdRegister[1]);
       } else
+        console.warn(process.env.SYSTEM_PRODUCTION ? errMsg('W6') : errMsg('W6', 'Include named-register.js for full named define support'));
         // TODO: create new warning number and documentation for using named define without named-register extra
         System.register(amdRegister[0], amdRegister[1]);
     } else

--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -63,44 +63,44 @@ import { errMsg } from '../err-msg.js';
   }
 
   global.define = function (arg1, arg2, arg3) {
-    var isNamedRegister = typeof arg1 === 'string'
+    var isNamedRegister = typeof arg1 === 'string';
     var name = isNamedRegister ? arg1 : null;
-    var depArg = isNamedRegister ? arg2 : arg1
-    var execArg = isNamedRegister ? arg3 : arg2
+    var depArg = isNamedRegister ? arg2 : arg1;
+    var execArg = isNamedRegister ? arg3 : arg2;
 
     // The System.register(deps, exec) arguments
-    var deps, exec
+    var deps, exec;
 
     // define([], function () {})
     if (Array.isArray(depArg)) {
       deps = depArg;
-      exec = execArg
+      exec = execArg;
     }
     // define({})
     else if (typeof depArg === 'object') {
-      deps = []
-      exec = function () { return depArg }
+      deps = [];
+      exec = function () { return depArg };
     }
     // define(function () {})
     else if (typeof depArg === 'function') {
-      deps = requireExportsModule
+      deps = requireExportsModule;
       exec = depArg;
     } else {
       // TODO: create new error number and documentation for invalid call to define()
     }
 
-    var amdRegister = createAMDRegister(deps, exec)
+    var amdRegister = createAMDRegister(deps, exec);
 
     if (isNamedRegister) {
       if (System.registerRegistry) {
         System.registerRegistry[name] = amdRegister;
-        System.register(name, amdRegister[0], amdRegister[1])
+        System.register(name, amdRegister[0], amdRegister[1]);
       } else {
         // TODO: create new warning number and documentation for using named define without named-register extra
-        System.register(amdRegister[0], amdRegister[1])
+        System.register(amdRegister[0], amdRegister[1]);
       }
     } else {
-      System.register(amdRegister[0], amdRegister[1])
+      System.register(amdRegister[0], amdRegister[1]);
     }
   };
   global.define.amd = {};

--- a/test/browser/amd.js
+++ b/test/browser/amd.js
@@ -82,4 +82,20 @@ suite('AMD tests', function () {
       assert.equal(m.default, false);
     });
   });
+
+  test('Throws an error when define() is called incorrectly', () => {
+    try {
+      define("strings are invalid amd modules");
+      assert.fail("define(str) should throw");
+    } catch (err) {
+      assert.equal(err.message.indexOf('Invalid call to AMD define') >= 0, true);
+    }
+
+    try {
+      define(1234);
+      assert.fail("define(num) should throw");
+    } catch (err) {
+      assert.equal(err.message.indexOf('Invalid call to AMD define') >= 0, true);
+    }
+  });
 });


### PR DESCRIPTION
See #2331. My comment there explains how the current behavior of amd.js' `System.getRegister()` implementation can be problematic.

This PR refactors the entire amd.js extra to be a lot simpler - `window.define()` calls `System.register()`, instead of maintaining its own latest amd register in memory. This way, system-core is in charge of clearing out the lastRegister and it also avoids much of the tricky edge cases with `tmpRegister`, `System.getRegister()`, and named registers.

All of the tests still pass, which I was quite excited about! I was thinking there would be edge cases where the getRegister functionality would expose nuances, but those were not revealed by any existing tests. I think there's a decent chance that such edge cases exist, but are not yet covered with tests. However, I still think this might be only worthy of a minor rather than a major, as the functionality is not intentionally changing.

If this approach doesn't have any fundamental flaws to it, I will finish up the remaining TODOs that I put in comments.