### PR TITLE
Fix warning with node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "./s.js": "./dist/s.min.js",
     "./package.json": "./package.json",
-    "./dist/*": "./dist/"
+    "./dist/*": "./dist/*"
   },
   "description": "Dynamic ES module loader",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "./s.js": "./dist/s.min.js",
     "./package.json": "./package.json",
-    "./dist/": "./dist/"
+    "./dist/*": "./dist/"
   },
   "description": "Dynamic ES module loader",
   "repository": {


### PR DESCRIPTION
This would fix this warning:
```
DeprecationWarning: Use of deprecated folder mapping "./dist/" in the "exports" field module resolution of the package at /path/to/node_modules/systemjs/package.json.
Update this package.json to use a subpath pattern like "./dist/*".
```