### PR TITLE
Fixes for named-register extra.

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -57,7 +57,7 @@ This function downloads and executes the code for a module. The promise must res
 
 The default system.js implementation is to append a script tag that downloads and executes the module's code, subsequently resolving the promise with the most recent register: `resolve(System.getRegister())`. [Example](https://github.com/systemjs/systemjs/blob/master/src/features/script-load.js).
 
-#### getRegister() -> [deps: String[], declare: Function]
+#### getRegister(url) -> [deps: String[], declare: Function]
 
 > This hook is intended for custom module format integrations only.
 

--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -17,10 +17,11 @@
   SystemJS.prototype = systemJSPrototype;
   System.constructor = SystemJS;
 
-  var firstNamedDefine;
+  var firstNamedDefine, firstName;
 
   function setRegisterRegistry(systemInstance) {
     systemInstance.registerRegistry = Object.create(null);
+    systemInstance.namedRegisterAliases = Object.create(null);
   }
 
   var register = systemJSPrototype.register;
@@ -31,10 +32,12 @@
     this.registerRegistry[name] = define;
     if (!firstNamedDefine) {
       firstNamedDefine = define;
-      Promise.resolve().then(function () {
-        firstNamedDefine = null;
-      });
+      firstName = name;
     }
+    setTimeout(function () {
+      firstNamedDefine = null;
+      firstName = null;
+    });
     return register.apply(this, [deps, declare]);
   };
 
@@ -45,7 +48,7 @@
       return resolve.call(this, id, parentURL);
     } catch (err) {
       if (id in this.registerRegistry) {
-        return id;
+        return this.namedRegisterAliases[id] || id;
       }
       throw err;
     }
@@ -63,12 +66,16 @@
   };
 
   var getRegister = systemJSPrototype.getRegister;
-  systemJSPrototype.getRegister = function () {
+  systemJSPrototype.getRegister = function (url) {
     // Calling getRegister() because other extras need to know it was called so they can perform side effects
-    var register = getRegister.call(this);
+    var register = getRegister.call(this, url);
 
+    if (firstName && url) {
+      this.namedRegisterAliases[firstName] = url;
+    }
     var result = firstNamedDefine || register;
     firstNamedDefine = null;
+    firstName = null;
     return result;
   }
 })(typeof self !== 'undefined' ? self : global);

--- a/src/extras/transform.js
+++ b/src/extras/transform.js
@@ -25,7 +25,7 @@ import { errMsg } from '../err-msg.js';
     })
     .then(function (source) {
       (0, eval)(source + '\n//# sourceURL=' + url);
-      return loader.getRegister();
+      return loader.getRegister(url);
     });
   };
 

--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -31,7 +31,7 @@ systemJSPrototype.instantiate = function (url, parent) {
       if (source.indexOf('//# sourceURL=') < 0)
         source += '\n//# sourceURL=' + url;
       (0, eval)(source);
-      return loader.getRegister();
+      return loader.getRegister(url);
     });
   });
 };

--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -76,7 +76,7 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
         reject(lastWindowError);
       }
       else {
-        var register = loader.getRegister();
+        var register = loader.getRegister(url);
         // Clear any auto import registration for dynamic import scripts during load
         if (register && register[0] === lastAutoImportDeps)
           clearTimeout(lastAutoImportTimeout);

--- a/src/features/worker-load.js
+++ b/src/features/worker-load.js
@@ -9,6 +9,6 @@ if (hasSelf && typeof importScripts === 'function')
     var loader = this;
     return Promise.resolve().then(function () {
       importScripts(url);
-      return loader.getRegister();
+      return loader.getRegister(url);
     });
   };

--- a/test/browser/named-register.js
+++ b/test/browser/named-register.js
@@ -171,4 +171,30 @@ suite('Named System.register', function() {
       assert.equal(m.b, 'b');
     });
   });
+
+  // https://github.com/systemjs/systemjs/issues/2349
+  test('Bundles with named register do not instantiate last module more than once', function () {
+    // First import the module via URL
+    return System.import('./fixtures/browser/named-instantiate-count.js').then(function (urlModule) {
+      // Then import the same module via named register name
+      return System.import('named-instantiate-count').then(function (namedModule) {
+        assert.equal(urlModule.getInstantiateCount(), 1);
+        assert.equal(namedModule.getInstantiateCount(), 1);
+        assert.equal(urlModule, namedModule);
+      });
+    });
+  });
+
+  // https://github.com/systemjs/systemjs/issues/2349
+  test('Named bundles that self import', function () {
+    // First import the module via URL
+    return System.import('./fixtures/browser/named-self-import.js').then(function (urlModule) {
+      // Then import the same module via named register name
+      return System.import('named-self-import').then(function (namedModule) {
+        assert.equal(urlModule.getInstantiateCount(), 1);
+        assert.equal(namedModule.getInstantiateCount(), 1);
+        assert.equal(urlModule, namedModule);
+      });
+    });
+  });
 });

--- a/test/fixtures/browser/named-instantiate-count.js
+++ b/test/fixtures/browser/named-instantiate-count.js
@@ -1,0 +1,12 @@
+let instantiateCount = 0;
+
+System.register("named-instantiate-count", [], function (_export) {
+  instantiateCount++;
+  return {
+    execute: function () {
+      _export('getInstantiateCount', function () {
+        return instantiateCount;
+      });
+    }
+  };
+});

--- a/test/fixtures/browser/named-self-import.js
+++ b/test/fixtures/browser/named-self-import.js
@@ -1,0 +1,31 @@
+let instantiateCount = 0;
+
+System.register("named-self-import", ["named-self-import/dep"], function (_export) {
+  instantiateCount++;
+  var dep;
+
+  return {
+    setters: [
+      function (d) {
+        dep = d;
+      }
+    ],
+    execute: function () {
+      dep.method();
+
+      _export('getInstantiateCount', function () {
+        return instantiateCount;
+      });
+    }
+  };
+});
+
+System.register("named-self-import/dep", [], function (_export) {
+  return {
+    execute: function () {
+      _export("method", function () {
+        return 1;
+      });
+    }
+  };
+});


### PR DESCRIPTION
This resolves #2349. It fixes two bugs:

1. When loading a bundle via System.import() with named registers, it is no longer possible for the first named register in the bundle to instantiate twice. Previously this was true, as the register array was instantiated once for the bundle of the module and once for the name it gave itself via a named register.
2. The named-register extra now always returns the first named register, rather than sometimes the first named define and sometimes the last named register

Demonstration of the bugs:

1. (todo)
2. [Last named register returned (script-load.js)](https://codesandbox.io/s/objective-moon-sdpp8?file=/index.html) and [First named register returned (transform.js)](https://codesandbox.io/s/hopeful-snyder-q9nq8?file=/index.html)

The changes I had to make to solve these bugs were more invasive than I was hoping for. It might be safest to release this is a new major version, as people are probably accidentally relying on the named-register extra to sometimes return the first named register and other times the last named register.

I'm open to all feedback on this one, as it was quite difficult and I tried several approaches before finding one that worked in all cases. The first bug is solved by creating a new `namedRegisterAliases` property on systemjs instances, to ensure that only one module is instantiated. The second bug is solved by switching from `Promise.resolve` to `setTimeout`, since the `load` event for `<script>` events seems to run after the `Promise.resolve()` executes.

Adding the url to the getRegister API was something I wanted to avoid, but ultimately was the least invasive approach I found that worked.

@guybedford I would appreciate your review on this one, if you're able to.