### PR TITLE
Use Promise.resolve in named-register. Resolves #2359.

### DIFF
--- a/src/extras/named-register.js
+++ b/src/extras/named-register.js
@@ -34,7 +34,7 @@
       firstNamedDefine = define;
       firstName = name;
     }
-    setTimeout(function () {
+    Promise.resolve().then(function () {
       firstNamedDefine = null;
       firstName = null;
     });


### PR DESCRIPTION
See #2359. During my refactor of named register in https://github.com/systemjs/systemjs/pull/2352, I unintentionally switched from setTimeout to Promise.resolve. This reverts that unintentional change and seems to fix the problem in the codesandbox in #2359