### PR TITLE
refactor: replace all `git.io` within the error message

### DIFF
--- a/src/err-msg.js
+++ b/src/err-msg.js
@@ -1,6 +1,6 @@
 export function errMsg(errCode, msg) {
   if (process.env.SYSTEM_PRODUCTION)
-    return (msg || "") + " (SystemJS https://git.io/JvFET#" + errCode + ")";
+    return (msg || "") + " (SystemJS https://github.com/systemjs/systemjs/blob/main/docs/errors.md#" + errCode + ")";
   else
-    return (msg || "") + " (SystemJS Error#" + errCode + " " + "https://git.io/JvFET#" + errCode + ")";
+    return (msg || "") + " (SystemJS Error#" + errCode + " " + "https://github.com/systemjs/systemjs/blob/main/docs/errors.md#" + errCode + ")";
 }

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -36,7 +36,7 @@ function processScripts () {
       System.import(script.src.slice(0, 7) === 'import:' ? script.src.slice(7) : resolveUrl(script.src, baseUrl)).catch(function (e) {
         // if there is a script load error, dispatch an "error" event
         // on the script tag.
-        if (e.message.indexOf('https://git.io/JvFET#3') > -1) {
+        if (e.message.indexOf('https://github.com/systemjs/systemjs/blob/main/docs/errors.md#3') > -1) {
           var event = document.createEvent('Event');
           event.initEvent('error', false, false);
           script.dispatchEvent(event);


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace `git.io` within the error message with its original URL.