### PR TITLE
Avoid Top-level await dependencies race condition

### DIFF
--- a/src/system-core.js
+++ b/src/system-core.js
@@ -275,6 +275,13 @@ function postOrderExec (loader, load, seen) {
   return doExec();
 
   function doExec () {
+    if (!load.e) {
+      if (load.er)
+        throw load.er;
+      if (load.E)
+        return load.E;
+      return;
+    }
     try {
       var execPromise = load.e.call(nullContext);
       if (execPromise) {

--- a/test/fixtures/tla/main1.js
+++ b/test/fixtures/tla/main1.js
@@ -1,0 +1,17 @@
+System.register(['./depa.js', './depb.js', './depc.js'], function (_export) {
+  var reporter;
+
+  return {
+    setters: [,, function (_depC) {
+      reporter = _depC.reporter;
+      _export('passed', _depC.passed);
+    }],
+    execute: function () {
+      reporter('main');
+      return new Promise(resolve => setTimeout(resolve, 100))
+      .then(function () {
+        reporter('main');
+      });
+    }
+  };
+});

--- a/test/fixtures/tla/main2.js
+++ b/test/fixtures/tla/main2.js
@@ -1,0 +1,17 @@
+System.register(['./depa.js', './depb.js', './depc.js'], function (_export) {
+  var reporter;
+
+  return {
+    setters: [,, function (_depC) {
+      reporter = _depC.reporter;
+      _export('passed', _depC.passed);
+    }],
+    execute: function () {
+      reporter('main');
+      return new Promise(resolve => setTimeout(resolve, 100))
+      .then(function () {
+        reporter('main');
+      });
+    }
+  };
+});

--- a/test/system-core.js
+++ b/test/system-core.js
@@ -409,6 +409,11 @@ describe('Loading Cases', function() {
   });
 
   describe('Top-level await', function () {
+    it('Should support top-level await with simultaneous imports', async function () {
+      const [m, n] = await Promise.all([loader.import('./tla/main1.js'), loader.import('./tla/main2.js')]);
+      assert.equal(m.passed, true);
+      assert.equal(n.passed, true);
+    });
     it('Should support top-level await', async function () {
       const m = await loader.import('./tla/main.js');
       assert.equal(m.passed, true);


### PR DESCRIPTION
Check if TLA is already ongoing when running the
`doExec` method and return the same promise.

resolves #2395 