### PR TITLE
Fix TLA: module should wait for its async dependencies

### DIFF
--- a/src/system-core.js
+++ b/src/system-core.js
@@ -242,8 +242,9 @@ var nullContext = Object.freeze(Object.create(null));
 // returns a promise if and only if a top-level await subgraph
 // throws on sync errors
 function postOrderExec (loader, load, seen) {
-  if (seen[load.id])
-    return;
+  if (seen[load.id]) {
+    return load.E;
+  }
   seen[load.id] = true;
 
   if (!load.e) {
@@ -270,9 +271,9 @@ function postOrderExec (loader, load, seen) {
     }
   });
   if (depLoadPromises)
-    return Promise.all(depLoadPromises).then(doExec);
+    return load.E = Promise.all(depLoadPromises).then(doExec);
 
-  return doExec();
+  return load.E = doExec();
 
   function doExec () {
     try {
@@ -288,7 +289,7 @@ function postOrderExec (loader, load, seen) {
           if (!process.env.SYSTEM_PRODUCTION) triggerOnload(loader, load, err, true);
           throw err;
         });
-        return load.E = execPromise;
+        return execPromise;
       }
       // (should be a promise, but a minify optimization to leave out Promise.resolve)
       load.C = load.n;

--- a/test/fixtures/tla/depc.js
+++ b/test/fixtures/tla/depc.js
@@ -2,7 +2,7 @@ System.register([], function (_export) {
   var reporter;
 
   var state = 0;
-  var expected = ['c', 'b', 'c', 'b', 'a', 'a', 'main', 'main'];
+  var expected = ['c', 'c', 'b', 'b', 'a', 'a', 'main', 'main'];
   var failed = false;
   function reporter (name) {
     if (expected[state++] !== name)


### PR DESCRIPTION
I found a BUG: if module _b_ depends on _a_ but _a_ has already been "seen"(`postOrderExec`-ed), then _b_  won't wait for _a_'s execution if _a_ is an async module.

During bug fixing, I also found test case `./test/system-core.js/Core API/Loading Cases/Top-level await/Should may be incorrect test case(which means equivalent module logic doesn't hold same semantic with ESM).  I also updated that expected behaviour.

I've upload my test code here: https://github.com/shrinktofit/systemjs-tla-bug-demo :

- case 1 show the BUG this PR wants to resolve.

- case 2 show the test case problem as described above.

- Both cases are written in ESM/TS and compiled into ESM and SystemJS.

- Run them one by one in browser:

  ![image](https://user-images.githubusercontent.com/28807867/176822550-58fa17bc-787b-4f83-abef-d8bf4fab375e.png)