### PR TITLE
Fix a concurrent bug due to async execution

### DIFF
--- a/test/fixtures/tla/concurrent-top-level-import-threads/async-dep.js
+++ b/test/fixtures/tla/concurrent-top-level-import-threads/async-dep.js
@@ -1,0 +1,9 @@
+// Equivalent to:
+// await Promise.resolve();
+System.register([], function (_export, _context) {
+    return {
+        execute: async function () {
+            await Promise.resolve();
+        },
+    };
+});

--- a/test/fixtures/tla/concurrent-top-level-import-threads/dep.js
+++ b/test/fixtures/tla/concurrent-top-level-import-threads/dep.js
@@ -1,0 +1,10 @@
+// Equivalent to:
+// import './async-dep.js';
+// export const stamp = Date.now();
+System.register(['./async-dep.js'], function (_export, _context) {
+    return {
+        execute: async function () {
+            _export('stamp', Date.now());
+        },
+    };
+});

--- a/test/fixtures/tla/concurrent-top-level-import-threads/main.js
+++ b/test/fixtures/tla/concurrent-top-level-import-threads/main.js
@@ -1,0 +1,9 @@
+// Equivalent to:
+// export { stamp } from './dep.js';
+System.register(['./dep.js'], function (_export, _context) {
+    return {
+        setters: [function (dep) {
+            _export('stamp', dep.stamp);
+        }]
+    };
+});

--- a/test/system-core.mjs
+++ b/test/system-core.mjs
@@ -454,6 +454,15 @@ describe('Loading Cases', function() {
       const m = await loader.import('main');
       assert.equal(m.default, 42);
     });
+    it('Concurrent top level import threads', async function() {
+        // Use two different top level entry is on purpose:
+        // currently top level lop would be cached.
+        const thread1 = loader.import('./tla/concurrent-top-level-import-threads/main.js');
+        const thread2 = loader.import('./tla/concurrent-top-level-import-threads/dep.js');
+        const main = await thread1;
+        const dep = await thread2;
+        assert.equal(main.stamp, dep.stamp);
+    });
   });
 
   describe('Export variations', function () {


### PR DESCRIPTION
Let me illustrate this BUG.

Here's 3 modules:

```ts
// main
export { stamp } from './dep.js';

// dep
import './async-dep.js';
export const stamp = Date.now();

// async-dep
await Promise.resolve();
```

And the top level execution flow:
```ts
const thread1 = import('main'); // #1
const thread2 = import('dep'); // #2
await thread1; // #3
await thread2; // #4
```

For module `dep`:

At the end of line #1, `load.E` was created. But `load.e` kept non-nil, since `dep` has async dependencies - the `load.e` only reset when `load.E` resolved.

Now enter line #2, because `!!load.e`, another `load.E`  would be created.

Starting from line #3, the two `load.E` raced - both call and reset `load.e`.