### PR TITLE
refactor: add the ability to custom eval

### DIFF
--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -9,7 +9,7 @@ import { resolveUrl } from '../common.js';
 
   var moduleTypesRegEx = /^[^#?]+\.(css|html|json|wasm)([?#].*)?$/;
   systemJSPrototype.shouldFetch = function (url) {
-    return moduleTypesRegEx.test(url);
+    return this.eval || moduleTypesRegEx.test(url);
   };
 
   var jsonContentType = /^application\/json(;|$)/;

--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -30,7 +30,7 @@ systemJSPrototype.instantiate = function (url, parent) {
     return res.text().then(function (source) {
       if (source.indexOf('//# sourceURL=') < 0)
         source += '\n//# sourceURL=' + url;
-      (0, eval)(source);
+        loader.eval ? (0, loader.eval)(source) : (0, eval)(source);
       return loader.getRegister(url);
     });
   });

--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -30,7 +30,7 @@ systemJSPrototype.instantiate = function (url, parent) {
     return res.text().then(function (source) {
       if (source.indexOf('//# sourceURL=') < 0)
         source += '\n//# sourceURL=' + url;
-        loader.eval ? (0, loader.eval)(source) : (0, eval)(source);
+      loader.eval ? (0, loader.eval)(source) : (0, eval)(source);
       return loader.getRegister(url);
     });
   });

--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -30,7 +30,7 @@ systemJSPrototype.instantiate = function (url, parent) {
     return res.text().then(function (source) {
       if (source.indexOf('//# sourceURL=') < 0)
         source += '\n//# sourceURL=' + url;
-      loader.eval ? (0, loader.eval)(source) : (0, eval)(source);
+      (0, loader.eval ? loader.eval : eval)(source);
       return loader.getRegister(url);
     });
   });


### PR DESCRIPTION
add the ability to custom eval , we hope also can choose whether to use fetch + eval to execute scripts。(like this： #2344 )

Our usage scenario is: we will use System.js to load some user-defined scripts, these scripts are not trusted, we want to use the sandbox to execute them.

```
System.constructor.prototype.eval = (code)=>{  // sandbox  }
```
