### PR TITLE
fix: avoid shortcut syntax for es5

### DIFF
--- a/src/features/fetch-load.js
+++ b/src/features/fetch-load.js
@@ -20,7 +20,7 @@ systemJSPrototype.instantiate = function (url, parent, meta) {
   return this.fetch(url, {
     credentials: 'same-origin',
     integrity: importMap.integrity[url],
-    meta
+    meta: meta,
   })
   .then(function (res) {
     if (!res.ok)


### PR DESCRIPTION
fix #2455 