### PR TITLE
Fix: Module types should support urls without quotes

### DIFF
--- a/src/extras/module-types.js
+++ b/src/extras/module-types.js
@@ -40,7 +40,7 @@ import { resolveUrl } from '../common.js';
         return res.text()
         .then(function (source) {
           source = source.replace(/url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g, function (match, quotes, relUrl1, relUrl2) {
-            return 'url(' + quotes + resolveUrl(relUrl1 || relUrl2, url) + quotes + ')';
+            return ['url(', quotes, resolveUrl(relUrl1 || relUrl2, url), quotes, ')'].join('');
           });
           return new Response(new Blob([
             'System.register([],function(e){return{execute:function(){var s=new CSSStyleSheet();s.replaceSync(' + JSON.stringify(source) + ');e("default",s)}}})'

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -227,6 +227,17 @@ suite('SystemJS Standard Tests', function() {
     });
   });
 
+  test('should handle css modules with urls without quotes', function () {
+    return System.import('fixturesbase/css-modules/url-without-quotes.css').then(function (m) {
+      assert.ok(m);
+      assert.ok(isCSSStyleSheet(m.default));
+      assert.equal(m.default.cssRules[0].cssText,'.hello { background-image: url("http://localhost:8080/test/fixtures/css-modules/path/to/image.png"); }')
+      assert.equal(m.default.cssRules[1].cssText,'.world { background-image: url("http://localhost:8080/test/fixtures/css-modules/path/to/image.png"); }')
+      assert.equal(m.default.cssRules[2].cssText,'body { background-image: url("http://localhost:8080/test/fixtures/css-modules/path/to/image.png"); }')
+      document.adoptedStyleSheets = document.adoptedStyleSheets.concat(m.default);
+    });
+  });
+
   test('should support application/javascript css module override', function () {
     return System.import('fixturesbase/css-modules/javascript.css').then(function (m) {
       assert.ok(m);

--- a/test/fixtures/css-modules/url-without-quotes.css
+++ b/test/fixtures/css-modules/url-without-quotes.css
@@ -1,0 +1,9 @@
+.hello {
+  background-image: url(./path/to/image.png);
+}
+.world {
+  background-image: url('./path/to/image.png');
+}
+body {
+  background-image: url("./path/to/image.png");
+}


### PR DESCRIPTION
This PR addresses the issue of undefined being concatenated into url strings when urls aren't wrapped in quotes.

I believe the fixture css I've added is valid for urls. I've not used chomp before. It changed some dist files when I ran it locally but I'm guessing you wouldn't want me to commit these changes in the PR. 🤔 

fixes: #2460