### PR TITLE
currentScript hook to try document.currentScript before lastScript

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -47,6 +47,12 @@ This hook could be asynchronous and you can fetch asynchronously some data and r
 
 Note that this hook does not apply to [module types](module-types.md), which use the default browser fetch implementation.
 
+#### getCurrentScript() -> HTMLScriptElement | null
+
+This function returns `document.currentScript` if it's defined, else it tries to look for the last script tag.  
+
+This is used when a SystemJS module is being loaded and registered with the `<script>` tag, such that SystemJS needs to get the element to the script to get its `src` attribute. 
+
 #### prepareImport() -> Promise
 
 This function is called before any `System.import` or dynamic import, returning a Promise that is resolved before continuing to perform the import.

--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -29,14 +29,26 @@ systemJSPrototype.createScript = function (url) {
   return script;
 };
 
+systemJSPrototype.getCurrentScript = function() {
+  if (hasDocument) {
+    var lastScript = document.currentScript;
+    if (!lastScript) {
+      var scripts = document.querySelectorAll('script[src]');
+      lastScript = scripts[scripts.length - 1];
+    }
+    return lastScript;
+  }
+
+  return null;
+}
+
 // Auto imports -> script tags can be inlined directly for load phase
 var lastAutoImportUrl, lastAutoImportDeps, lastAutoImportTimeout;
 var autoImportCandidates = {};
 var systemRegister = systemJSPrototype.register;
 systemJSPrototype.register = function (deps, declare) {
   if (hasDocument && document.readyState === 'loading' && typeof deps !== 'string') {
-    var scripts = document.querySelectorAll('script[src]');
-    var lastScript = scripts[scripts.length - 1];
+    var lastScript = this.getCurrentScript();
     if (lastScript) {
       lastAutoImportUrl = lastScript.src;
       lastAutoImportDeps = deps;


### PR DESCRIPTION
fix https://github.com/systemjs/systemjs/issues/2465

Adds a hook function `getCurrentScript` that try `document.currentScript` before getting the lastScript.

