### PR TITLE
feat: add support for reading the mapping of loaded imports

### DIFF
--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -21,7 +21,7 @@ systemJSPrototype.prepareImport = function (doProcessScripts) {
 };
 
 systemJSPrototype.getImportMap = function () {
-  return importMap;
+  return JSON.parse(JSON.stringify(importMap));
 };
 
 if (hasDocument) {

--- a/src/features/import-maps.js
+++ b/src/features/import-maps.js
@@ -19,6 +19,11 @@ systemJSPrototype.prepareImport = function (doProcessScripts) {
   }
   return importMapPromise;
 };
+
+systemJSPrototype.getImportMap = function () {
+  return importMap;
+};
+
 if (hasDocument) {
   processScripts();
   window.addEventListener('DOMContentLoaded', processScripts);

--- a/test/system-core.mjs
+++ b/test/system-core.mjs
@@ -272,6 +272,17 @@ describe('Core API', function () {
 
       assert([...loader.entries()].some(entry => entry[0] === 'http://i' && entry[1].a === 'b'));
     })
+
+    it('Supports System.getImportMap', function () {
+      const importMap = loader.getImportMap();
+
+      assert(
+        Object.hasOwn(importMap, 'imports') && 
+        Object.hasOwn(importMap, 'scopes') && 
+        Object.hasOwn(importMap, 'depcache') && 
+        Object.hasOwn(importMap, 'integrity')
+      );
+    })
   });
 });
 


### PR DESCRIPTION
# Description

During the implementation of the library, I needed to read the values from the mapping without the need to call the import file again via fetch. Since I didn't see anything within the code that could provide these values, I'm sending this addition if possible.

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf8" />
    <link rel="icon" href="data:," />
    <script type="systemjs-importmap" src="./import-map.json"></script>
  </head>
  <body>
    <script>
      const importMap = System.getImportMap();
    </script>
  </body>
</html>
```