### PR TITLE
Feat: Support module.uri in AMD extra

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -40,11 +40,12 @@ import { errMsg } from '../err-msg.js';
     if (splice)
       amdDefineDeps.length -= splice;
     var amdExec = amdDefineExec;
-    return [amdDefineDeps, function (_export) {
+    return [amdDefineDeps, function (_export, _context) {
       _export({ default: exports, __useDefault: true });
       return {
         setters: setters,
         execute: function () {
+          module.uri = _context.meta.url;
           var amdResult = amdExec.apply(exports, depModules);
           if (amdResult !== undefined)
             module.exports = amdResult;

--- a/test/browser/amd.js
+++ b/test/browser/amd.js
@@ -90,6 +90,13 @@ suite('AMD tests', function () {
     });
   });
 
+  test('Has access to module.uri (context meta)', function () {
+    return System.import('fixtures/amd-module-meta.js').then(function (m) {
+      assert.ok(m.default);
+      assert.equal(m.default.uri, baseURL+'fixtures/browser/amd-module-meta.js');
+    });
+  });
+
   test('Throws an error when define() is called incorrectly', () => {
     try {
       define("strings are invalid amd modules");

--- a/test/fixtures/browser/amd-module-meta.js
+++ b/test/fixtures/browser/amd-module-meta.js
@@ -1,0 +1,5 @@
+define(["module"], function (module) {
+  return {
+    uri: module.uri,
+  };
+});


### PR DESCRIPTION
AMD modules loaded via SystemJS should have some way of knowing where they are loading from so they can load their assets. This is mentioned in the requirejs docs [here](https://github.com/requirejs/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#module). With this an amd webpack build can then use it to setup `__webpack_public_path__`. e.g.

```
__webpack_public_path__ = module.uri.slice(0, module.uri.lastIndexOf('/') + 1);
```

Fixes: #2386

**Notes for reviewers:**
Should I update version and run the `build` script in this PR to update the dist files or does that happen via github-actions after a merge to main?