### PR TITLE
Fix TLA: module should wait for its async dependencies

### DIFF
--- a/test/fixtures/tla/depc.js
+++ b/test/fixtures/tla/depc.js
@@ -2,7 +2,7 @@ System.register([], function (_export) {
   var reporter;
 
   var state = 0;
-  var expected = ['c', 'b', 'c', 'b', 'a', 'a', 'main', 'main'];
+  var expected = ['c', 'c', 'b', 'b', 'a', 'a', 'main', 'main'];
   var failed = false;
   function reporter (name) {
     if (expected[state++] !== name)

--- a/test/fixtures/tla/top-level-async-import/dep-a.js
+++ b/test/fixtures/tla/top-level-async-import/dep-a.js
@@ -1,0 +1,12 @@
+// Equivalent to:
+// await new Promise((resolve) => setTimeout(resolve));
+// export default class A { constructor() { this.value = 6; } });
+System.register([], function (_export, _context) {
+    return {
+        setters: [],
+        execute: async function() {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+            _export('default', class A { constructor() { this.value = 6; } });
+        },
+    };
+});

--- a/test/fixtures/tla/top-level-async-import/dep-b.js
+++ b/test/fixtures/tla/top-level-async-import/dep-b.js
@@ -1,0 +1,15 @@
+// Equivalent to:
+// import A from './dep-a';
+// export default new A().value;
+System.register(['./dep-a.js'], function(_export, _context) {
+    var _dep_a;
+    return {
+        setters: [function(dep_a){
+            _dep_a = dep_a;
+        }],
+        execute: function() {
+            var A = _dep_a.default;
+            _export('default', new A().value);
+        },
+    };
+});

--- a/test/fixtures/tla/top-level-async-import/main.js
+++ b/test/fixtures/tla/top-level-async-import/main.js
@@ -1,0 +1,15 @@
+// Equivalent to:
+// import './dep-a';
+// import b from './dep-b';
+// export default b;
+System.register(['./dep-a.js', './dep-b.js'], function(_export, _context) {
+    var _dep_b, _dep_c;
+    return {
+        setters: [null, function(dep_b){
+            _dep_b = dep_b;
+        }],
+        execute: function () {
+            _export('default', _dep_b.default);
+        },
+    };
+});

--- a/test/system-core.mjs
+++ b/test/system-core.mjs
@@ -474,6 +474,10 @@ describe('Loading Cases', function() {
         const dep = await thread2;
         assert.equal(main.stamp, dep.stamp);
     });
+    it('Concurrent top level async dependency ordering', async function() {
+        const main = await loader.import('./tla/top-level-async-import/main.js');
+        assert.equal(main.default, 6);
+    });
   });
 
   describe('Export variations', function () {


### PR DESCRIPTION
Reopening https://github.com/systemjs/systemjs/pull/2402 since the case is still valid.

> If module b depends on a but a has already been "seen"(postOrderExec-ed), then b won't wait for a's execution if a is an async module.
> 
> During bug fixing, I also found test case `./test/system-core.js/Core API/Loading Cases/Top-level await/Should may be incorrect test case(which means equivalent module logic doesn't hold same semantic with ESM). I also updated that expected behaviour.
> 
> case 1 show the BUG this PR wants to resolve.
> 
> case 2 show the test case problem as described above.
> 
> ![](https://user-images.githubusercontent.com/28807867/176822550-58fa17bc-787b-4f83-abef-d8bf4fab375e.png)