### PR TITLE
WIP: fixe vue2 like amd export, when import vue2 as externals

### DIFF
--- a/src/extras/amd.js
+++ b/src/extras/amd.js
@@ -51,6 +51,10 @@ import { errMsg } from '../err-msg.js';
             module.exports = amdResult;
           _export(module.exports);
           _export('default', module.exports);
+          // Vue2 like
+          if (typeof amdResult === 'function') {
+            _export('__esModule', true);
+          }
         }
       };
     }];


### PR DESCRIPTION
*This is not ready for merge. It's clearer to tell with code.*

#### Background

There were issues about **AMD**, but were asked with keyword **UMD**. So let's be clear first that, this issue is about `window.define`, not `window.Vue`.

Vue3 [refused](https://github.com/vuejs/core/issues/1136) to support AMD but only window.Vue. So this issue is not about vue3 either.

#### Problem

[vue@2.6.14](https://[unpkg.com/vue@2.6.14/dist/vue.runtime.js](https://unpkg.com/vue@2.6.14/dist/vue.runtime.js)) implements AMD *inconsiderately*, like:

```javascript
define(function () {
  function Vue() {};
  Vue.component = function () {};
  Vue.version = '2.6.14';
  return Vue;
});
```

[vue-router@3.6.5](https://[unpkg.com/vue-router@3.6.5/dist/vue-router.js](https://unpkg.com/vue-router@3.6.5/dist/vue-router.js)) and the vue2 ecosystem have a common practice to use each other's `prototype`, like:

```javascript
define(function () {
  function VueRouter() {};
  Object.defineProperty(Vue.prototype, '$router', ...);
  return VueRouter();
});
```

But the actual imported Vue is `{ component: ..., version: ... }`, not `function Vue`. So there will be no `prototype` and will throw error.

#### Debug

[react@18.2.0/umd](https://unpkg.com/react@18.2.0/umd/react.development.js) implements AMD correctly, like:

```javascript
define(["exports"], function (exports) {
  exports.createContext = createContext;
  exports.version = "18.2.0";
});
```

The imported React is a plain object `{ createElement: function }`. You can use it with `React.createElement`. You will not use `new React()` nor `React.prototype`.

The `_export` implement of `SystemJS` will clone every key of original external lib to internal defined module.

But the `_export` will not clone `prototype` nor `constructor`. So for vue, you can use `Vue.component` because it is cloned. But you cannot use `Vue.prototype` because it is not cloned.

#### Workaround

I noticed that the `extra/amd` **always** keep the **original** module to `default`, i.e. `{ default: function Vue }`. And that is exactly the **workable** Vue we want.

Technically, I think set `{ __esModule: true }` everywhere where if `{ __useDefault: true }` should work.

I'm not sure about the compatibility. So I proposed to set only if `{ __useDefault: true }` and `typeof returnedOriginalModule === 'function'`.