### PR TITLE
Handle script loading error events

### DIFF
--- a/src/features/script-load.js
+++ b/src/features/script-load.js
@@ -66,7 +66,15 @@ systemJSPrototype.instantiate = function (url, firstParentUrl) {
   return Promise.resolve(systemJSPrototype.createScript(url)).then(function (script) {
     return new Promise(function (resolve, reject) {
       script.addEventListener('error', function () {
-        reject(Error(errMsg(3, process.env.SYSTEM_PRODUCTION ? [url, firstParentUrl].join(', ') : 'Error loading ' + url + (firstParentUrl ? ' from ' + firstParentUrl : ''))));
+        try {
+          throw new Error(errMsg(3, process.env.SYSTEM_PRODUCTION ? [url, firstParentUrl].join(', ') : 'Error loading ' + url + (firstParentUrl ? ' from ' + firstParentUrl : '')));
+        } catch (error) {
+          setTimeout(() => {
+            throw error;
+          });
+          const emptyInstantiation = [[], function () { return {} }];
+          resolve(emptyInstantiation);
+        }
       });
       script.addEventListener('load', function () {
         document.head.removeChild(script);


### PR DESCRIPTION
Use const module = System.register(['moment', 'AMap'], function(){}) to define the module and its dependencies. Most of the pages use these two dependent dependencies, but a small number of pages do not. . When we load this small part of the page, the moment loading fails, which will cause the page rendering that does not use the moment to fail. This is not acceptable.

We hope that dependencies will not affect the execution of the module. When dependencies are used, an error will be reported.