### PR TITLE
feat: context.resolve now returns string

### DIFF
--- a/docs/system-register.md
+++ b/docs/system-register.md
@@ -65,18 +65,16 @@ This is useful for referencing assets by URL in a way that is supported in many 
 const assetUrl = new URL('./asset.ext', import.meta.url);
 ```
 
-#### import.meta.resolve: (id, parentUrl?) => Promise<String>
+#### import.meta.resolve: (id, parentUrl?) => String
 
-> `import.meta.resolve` currently has no specification or browser implementation and may still change.
-
-`_context.meta.resolve` implements `import.meta.resolve` similarly to Node.js.
+`_context.meta.resolve` implements `import.meta.resolve` similarly to Node.js 18+
 
 This can be used to resolve import map resolutions or assets:
 
 ```js
-const resolvedDep = await import.meta.resolve('dep');
-const localAsset = await import.meta.resolve('./asset.ext');
-const depPath = await import.meta.resolve('dep/');
+const resolvedDep = import.meta.resolve('dep');
+const localAsset = import.meta.resolve('./asset.ext');
+const depPath = import.meta.resolve('dep/');
 ```
 
 #### Top-level await

--- a/src/system-core.js
+++ b/src/system-core.js
@@ -46,7 +46,7 @@ systemJSPrototype.createContext = function (parentId) {
   return {
     url: parentId,
     resolve: function (id, parentUrl) {
-      return Promise.resolve(loader.resolve(id, parentUrl || parentId));
+      return loader.resolve(id, parentUrl || parentId);
     }
   };
 };

--- a/test/browser/core.js
+++ b/test/browser/core.js
@@ -59,20 +59,14 @@ suite('SystemJS Standard Tests', function() {
 
   test('import.meta.resolve package maps', function () {
     return System.import('fixtures/resolve.js').then(function (m) {
-      return m.resolve('a')
+      assert.equal(m.resolve('a'), rootURL + 'b');
     })
-    .then(function (resolved) {
-      assert.equal(resolved, rootURL + 'b');
-    });
   });
 
   test('import.meta.resolve package maps paths', function () {
     return System.import('fixtures/resolve.js').then(function (m) {
-      return m.resolve('a/')
+      assert.equal(m.resolve('a/'), baseURL + 'fixtures/browser/a/');
     })
-    .then(function (resolved) {
-      assert.equal(resolved, baseURL + 'fixtures/browser/a/');
-    });
   });
 
   test('Contextual package maps', function () {
@@ -84,10 +78,10 @@ suite('SystemJS Standard Tests', function() {
 
   test('import.meta.resolve contextual package maps', function () {
     return System.import('fixtures/resolve.js').then(function (m) {
-      return m.resolve('maptest', baseURL + 'fixtures/browser/scope-test/index.js')
-    })
-    .then(function (resolved) {
-      assert.equal(resolved, baseURL + 'fixtures/browser/contextual-map-dep.js');
+      assert.equal(
+        m.resolve('maptest', baseURL + 'fixtures/browser/scope-test/index.js'),
+        baseURL + 'fixtures/browser/contextual-map-dep.js'
+      );
     });
   });
 
@@ -279,10 +273,7 @@ suite('SystemJS Standard Tests', function() {
 
   test('import.meta.resolve', function () {
     return System.import('fixtures/resolve.js').then(function (m) {
-      return m.resolve('./test.js')
-    })
-    .then(function (resolved) {
-      assert.equal(resolved, baseURL + 'fixtures/browser/test.js');
+      assert.equal(m.resolve('./test.js'), baseURL + 'fixtures/browser/test.js');
     });
   });
 


### PR DESCRIPTION
import.meta.resolve on node and browser returns a string - update implementation of createContext to match.

Runtime behavior of existing code should continue to work

old behavior
```
const url = await import.meta.resolve('./foo')
```

new behavior
```
const url = import.meta.resolve('./foo')
```

Runtime behavior may be backward compatible since awaiting a string results in a string.

Note that types for Node already reflect the new behavior.

BREAKING CHANGE:  runtime behavior of import.meta.resolve changes from async to sync