### PR TITLE
feat: modernize Node target, Requires Node 18.13+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
       - name: Setup Chrome ${{ matrix.chrome }}
+        id: setup-chrome
         uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: ${{ matrix.chrome }}
@@ -31,5 +32,5 @@ jobs:
       - name: Chomp Test
         run: chomp test
         env: 
-          CI_BROWSER: C:\hostedtoolcache\windows\setup-chrome\chromium\latest\x64\chrome.exe
+          CI_BROWSER: ${{ steps.setup-chrome.outputs.chrome-path }}
           CI_BROWSER_FLAGS:

--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ The [4.2KB system.js loader](dist/system.min.js) adds the following features in 
 * Supports loading Wasm, CSS and JSON [module types](docs/module-types.md).
 * Includes the [global loading extra](#extras) for loading global scripts, useful for loading library dependencies traditionally loaded with script tags.
 
-#### 3. system-node.cjs loader
+#### 3. system-node.cjs / system-node.mjs loader
 
-The [system-node.cjs](/dist/system-node.cjs) loader is a version of SystemJS build designed to run in Node.js, typically for workflows where System modules need to be executed on the server like SSR. It has the following features:
+The [system-node.cjs](/dist/system-node.cjs) and [system-node.mjs](/dist/system-node.mjs) loaders are versions of SystemJS designed to run in Node.js (requires **Node.js 18.13+**), typically for workflows where System modules need to be executed on the server like SSR. They have the following features:
 
-* Loading System modules from disk (via `file://` urls) or the network, with included caching that respects the Content-Type header.
+* Loading System modules from disk (via `file://` urls) or the network, with Content-Type based module handling.
 * Import Maps (via the `applyImportMap` api).
 * [Tracing hooks](docs/hooks.md#trace-hooks) and [registry deletion API](docs/api.md#registry) for reloading workflows.
 * Loading global modules with the included [global loading extra](#extras).
+* Source map support for improved stack traces (Node.js 20+, using built-in `module.SourceMap`).
 
 _Loading CommonJS modules is not currently supported in this loader and likely won't be. If you find you need them it is more advisable to use [Node.js native module support](https://nodejs.org/dist/latest/docs/api/esm.html) where possible instead of the SystemJS Node.js loader._
 

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -6,13 +6,12 @@ extensions = [
   'chomp@0.1:npm',
   'chomp@0.1:footprint',
   './terser.js',
-  'chomp@0.1:rollup',
-  'chomp@0.1:ncc'
+  'chomp@0.1:rollup'
 ]
 
 [[task]]
 name = 'build'
-deps = ['dist/system.js', 'dist/system.min.js', 'dist/s.js', 'dist/s.min.js', 'dist/system-node.cjs', 'dist/extras/*.js']
+deps = ['dist/system.js', 'dist/system.min.js', 'dist/s.js', 'dist/s.min.js', 'dist/system-node.cjs', 'dist/system-node.mjs', 'dist/extras/*.js']
 
 [[task]]
 target = 'dist/system.js'
@@ -86,10 +85,30 @@ unsafe = false
 [[task]]
 target = 'dist/system-node.cjs'
 deps = ['src/system-node.js', 'package.json', 'src/system-core.js', 'src/common.js', 'src/err-msg.js', 'src/features/*.js']
-template = 'ncc'
+template = 'rollup'
 [task.template-options]
-assets = false
-esm = false
+onwarn = false
+[task.template-options.output]
+format = 'cjs'
+strict = false
+[[task.template-options.plugin]]
+package = '@rollup/plugin-replace'
+"process.env.SYSTEM_PRODUCTION" = 'false'
+"process.env.SYSTEM_BROWSER" = 'false'
+
+[[task]]
+target = 'dist/system-node.mjs'
+deps = ['src/system-node.js', 'package.json', 'src/system-core.js', 'src/common.js', 'src/err-msg.js', 'src/features/*.js']
+template = 'rollup'
+[task.template-options]
+onwarn = false
+[task.template-options.output]
+format = 'es'
+strict = false
+[[task.template-options.plugin]]
+package = '@rollup/plugin-replace'
+"process.env.SYSTEM_PRODUCTION" = 'false'
+"process.env.SYSTEM_BROWSER" = 'false'
 
 [[task]]
 name = 'footprint'

--- a/dist/system-node.mjs
+++ b/dist/system-node.mjs
@@ -1,8 +1,6 @@
-Object.defineProperty(exports, '__esModule', { value: true });
-
-var fs = require('fs');
-var url = require('url');
-var module$1 = require('module');
+import { readFileSync, promises } from 'fs';
+import { fileURLToPath } from 'url';
+import { SourceMap } from 'module';
 
 function errMsg(errCode, msg) {
   return (msg || "") + " (SystemJS Error#" + errCode + " " + "https://github.com/systemjs/systemjs/blob/main/docs/errors.md#" + errCode + ")";
@@ -765,7 +763,7 @@ systemJSPrototype.instantiate = function (url, parent, meta) {
   });
 };
 
-var hasSourceMapSupport = typeof module$1.SourceMap === 'function';
+var hasSourceMapSupport = typeof SourceMap === 'function';
 
 if (hasSourceMapSupport) {
   var sourceMapUrls = Object.create(null);
@@ -776,8 +774,8 @@ if (hasSourceMapSupport) {
     var mapUrl = sourceMapUrls[fileName];
     if (!mapUrl) return;
     try {
-      var mapSource = fs.readFileSync(url.fileURLToPath(mapUrl), 'utf-8');
-      sourceMapCache[fileName] = new module$1.SourceMap(JSON.parse(mapSource));
+      var mapSource = readFileSync(fileURLToPath(mapUrl), 'utf-8');
+      sourceMapCache[fileName] = new SourceMap(JSON.parse(mapSource));
       return sourceMapCache[fileName];
     } catch (e) {
       // Remove bad entry so we don't retry
@@ -845,13 +843,13 @@ var addSourceMapUrl = hasSourceMapSupport
   : function () {};
 
 global.System.constructor.prototype.shouldFetch = () => true;
-global.System.constructor.prototype.fetch = async url$1 => {
-  if (url$1.startsWith('file:')) {
+global.System.constructor.prototype.fetch = async url => {
+  if (url.startsWith('file:')) {
     try {
-      const source = await fs.promises.readFile(url.fileURLToPath(url$1.toString()), 'utf-8');
+      const source = await promises.readFile(fileURLToPath(url.toString()), 'utf-8');
 
       // Cache the source map URL for lazy loading on error
-      addSourceMapUrl(url$1, source);
+      addSourceMapUrl(url, source);
 
       return {
         ok: true,
@@ -882,7 +880,7 @@ global.System.constructor.prototype.fetch = async url$1 => {
   } else {
     if (typeof fetch === 'undefined')
       throw new Error('SystemJS requires Node.js 18.13 or later for native fetch. For older versions, override System.constructor.prototype.fetch (see docs/nodejs.md).');
-    return fetch(url$1);
+    return fetch(url);
   }
 };
 
@@ -1020,6 +1018,4 @@ function ensureValidSystemLoader (loader) {
     throw new Error('A valid SystemJS instance must be provided');
 }
 
-exports.System = System$1;
-exports.applyImportMap = applyImportMap;
-exports.setBaseUrl = setBaseUrl;
+export { System$1 as System, applyImportMap, setBaseUrl };

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -1,6 +1,10 @@
 # NodeJS Loader
 
-The `system-node.cjs` build adds support for loading modules in NodeJS.
+The `system-node.cjs` and `system-node.mjs` builds add support for loading modules in NodeJS. Requires **Node.js 18.13 or later**.
+
+* **Node.js 18.13+** — Full functionality with native `fetch` for HTTP module loading.
+* **Node.js 20+** — Adds source map support for improved stack traces (via built-in `module.SourceMap`).
+* **Older Node.js** — File loading works. HTTP loading requires overriding [`System.constructor.prototype.fetch`](#custom-fetch-hook).
 
 ## Installation
 
@@ -12,7 +16,11 @@ yarn add systemjs
 ```
 
 ```js
+// CommonJS
 const { System, applyImportMap, setBaseUrl } = require('systemjs');
+
+// ESM
+import { System, applyImportMap, setBaseUrl } from 'systemjs';
 
 System.import('file:///Users/name/some-module.js').then(module => {
   console.log("The loaded module", module);
@@ -29,7 +37,7 @@ Separate instances of SystemJS, each with their own import map and module regist
 
 Additionally, [global loading](/README.md#extras), [module types](/docs/module-types.md), and the [SystemJS Registry API](/docs/api.md#registry) are supported. Other extras, such as the AMD extra, have not been thoroughly tested but are presumed to work.
 
-Modules loaded over HTTP will be loaded via [node-fetch](https://github.com/node-fetch/node-fetch).
+Modules loaded over HTTP are loaded using Node's native `fetch` API. Source map support for improved stack traces is provided using Node's built-in `module.SourceMap` when available.
 
 ## API
 
@@ -106,4 +114,23 @@ setBaseUrl(System, 'https://example.com/base/');
 // Use a file URL as the base
 setBaseUrl(System, 'file:///Users/name/some-dir/');
 setBaseUrl(System, pathToFileURL(path.join(process.cwd(), 'some-dir')) + path.sep);
+```
+
+### Custom fetch hook
+
+The built-in fetch handler supports `file://` URLs via the filesystem and HTTP/HTTPS URLs via Node's native `fetch` (Node 20+). You can override the fetch hook to customize network loading, for example to use `node-fetch` on older Node versions or to add custom headers:
+
+```js
+const { System } = require('systemjs');
+const originalFetch = System.constructor.prototype.fetch;
+
+System.constructor.prototype.fetch = function (url, options) {
+  // Let file:// URLs use the built-in handler
+  if (url.startsWith('file:'))
+    return originalFetch.call(this, url, options);
+
+  // Custom network fetch (e.g., using node-fetch for older Node versions)
+  const nodeFetch = require('node-fetch');
+  return nodeFetch(url, options);
+};
 ```

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -118,7 +118,7 @@ setBaseUrl(System, pathToFileURL(path.join(process.cwd(), 'some-dir')) + path.se
 
 ### Custom fetch hook
 
-The built-in fetch handler supports `file://` URLs via the filesystem and HTTP/HTTPS URLs via Node's native `fetch` (Node 20+). You can override the fetch hook to customize network loading, for example to use `node-fetch` on older Node versions or to add custom headers:
+The built-in fetch handler supports `file://` URLs via the filesystem and HTTP/HTTPS URLs via Node's native `fetch` (Node.js 18.13+). You can override the fetch hook to customize network loading, for example to use `node-fetch` on older Node versions or to add custom headers:
 
 ```js
 const { System } = require('systemjs');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "main": "dist/system-node.cjs",
   "exports": {
     ".": {
-      "node": "./dist/system-node.cjs",
+      "node": {
+        "import": "./dist/system-node.mjs",
+        "require": "./dist/system-node.cjs"
+      },
       "default": "./dist/system.min.js"
     },
     "./s.js": "./dist/s.min.js",
@@ -17,8 +20,11 @@
     "url": "git://github.com/systemjs/systemjs"
   },
   "author": "Guy Bedford",
-  "type": "script",
+  "type": "commonjs",
   "license": "MIT",
+  "engines": {
+    "node": ">=18.13.0"
+  },
   "files": [
     "dist"
   ],
@@ -31,18 +37,15 @@
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.4.2",
-    "@vercel/ncc": "^0.34.0",
     "bluebird": "^3.7.2",
     "construct-style-sheets-polyfill": "^2.3.5",
     "kleur": "^4.1.5",
     "mkdirp": "^1.0.4",
     "mocha": "^7.1.1",
-    "node-fetch": "^2.6.0",
     "open": "^8.4.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-terser": "^5.3.0",
-    "source-map-support": "^0.5.16",
     "symbol-es6": "^0.1.2",
     "terser": "^5.16.5",
     "whatwg-fetch": "^3.0.0"

--- a/src/features/node-fetch.js
+++ b/src/features/node-fetch.js
@@ -1,15 +1,16 @@
-import sourceMapSupport from 'source-map-support';
-import fetch from 'node-fetch';
 import { promises as fs } from 'fs';
 import { fileURLToPath } from 'url';
-
-sourceMapSupport.install();
+import { addSourceMapUrl } from './node-sourcemap.js';
 
 global.System.constructor.prototype.shouldFetch = () => true;
 global.System.constructor.prototype.fetch = async url => {
   if (url.startsWith('file:')) {
     try {
-      const source = await fs.readFile(fileURLToPath(url.toString()));
+      const source = await fs.readFile(fileURLToPath(url.toString()), 'utf-8');
+
+      // Cache the source map URL for lazy loading on error
+      addSourceMapUrl(url, source);
+
       return {
         ok: true,
         status: 200,
@@ -23,10 +24,10 @@ global.System.constructor.prototype.fetch = async url => {
           }
         },
         async text () {
-          return source.toString();
+          return source;
         },
         async json () {
-          return JSON.parse(source.toString());
+          return JSON.parse(source);
         }
       };
     }
@@ -37,6 +38,8 @@ global.System.constructor.prototype.fetch = async url => {
         return { status: 500, statusText: e.toString() };
     }
   } else {
+    if (typeof fetch === 'undefined')
+      throw new Error('SystemJS requires Node.js 18.13 or later for native fetch. For older versions, override System.constructor.prototype.fetch (see docs/nodejs.md).');
     return fetch(url);
   }
 };

--- a/src/features/node-sourcemap.js
+++ b/src/features/node-sourcemap.js
@@ -37,8 +37,8 @@ if (hasSourceMapSupport) {
 
     var mappedStack = callSites.map(function (callSite) {
       var fileName = callSite.getScriptNameOrSourceURL();
-      var lineNumber = callSite.getLineNumber();
-      var columnNumber = callSite.getColumnNumber();
+      var lineNumber = callSite.getLineNumber() || 0;
+      var columnNumber = callSite.getColumnNumber() || 0;
       var sm = fileName && getSourceMap(fileName);
 
       if (sm) {

--- a/src/features/node-sourcemap.js
+++ b/src/features/node-sourcemap.js
@@ -1,0 +1,82 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { SourceMap } from 'module';
+
+export var hasSourceMapSupport = typeof SourceMap === 'function';
+
+if (hasSourceMapSupport) {
+  var sourceMapUrls = Object.create(null);
+  var sourceMapCache = Object.create(null);
+
+  var getSourceMap = function (fileName) {
+    if (sourceMapCache[fileName]) return sourceMapCache[fileName];
+    var mapUrl = sourceMapUrls[fileName];
+    if (!mapUrl) return;
+    try {
+      var mapSource = readFileSync(fileURLToPath(mapUrl), 'utf-8');
+      sourceMapCache[fileName] = new SourceMap(JSON.parse(mapSource));
+      return sourceMapCache[fileName];
+    } catch (e) {
+      // Remove bad entry so we don't retry
+      delete sourceMapUrls[fileName];
+    }
+  };
+
+  var originalPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = function (error, callSites) {
+    var hasMapping = callSites.some(function (callSite) {
+      var fileName = callSite.getScriptNameOrSourceURL();
+      return fileName && (sourceMapCache[fileName] || sourceMapUrls[fileName]);
+    });
+
+    if (!hasMapping) {
+      return originalPrepareStackTrace
+        ? originalPrepareStackTrace(error, callSites)
+        : error + '\n' + callSites.map(function (s) { return '    at ' + s; }).join('\n');
+    }
+
+    var mappedStack = callSites.map(function (callSite) {
+      var fileName = callSite.getScriptNameOrSourceURL();
+      var lineNumber = callSite.getLineNumber();
+      var columnNumber = callSite.getColumnNumber();
+      var sm = fileName && getSourceMap(fileName);
+
+      if (sm) {
+        var entry = sm.findEntry(lineNumber - 1, columnNumber - 1);
+        if (entry && entry.originalSource) {
+          var source = entry.originalSource;
+          var line = entry.originalLine + 1;
+          var column = entry.originalColumn + 1;
+          var fnName = callSite.getFunctionName();
+          return '    at ' + (fnName ? fnName + ' ' : '') + '(' + source + ':' + line + ':' + column + ')';
+        }
+      }
+
+      return '    at ' + callSite;
+    });
+
+    return error + '\n' + mappedStack.join('\n');
+  };
+
+  // Clean up source map caches when modules are deleted
+  var origDelete = global.System.constructor.prototype.delete;
+  global.System.constructor.prototype.delete = function (id) {
+    delete sourceMapUrls[id];
+    delete sourceMapCache[id];
+    if (origDelete) {
+      return origDelete.apply(this, arguments);
+    }
+    return false;
+  };
+} else {
+  console.warn('SystemJS source map support requires Node.js 20 or later');
+}
+
+export var addSourceMapUrl = hasSourceMapSupport
+  ? function (url, source) {
+    var match = source.match(/\/\/[#@]\s*sourceMappingURL=(.+)\s*$/m);
+    if (match) {
+      sourceMapUrls[url] = new URL(match[1], url).href;
+    }
+  }
+  : function () {};

--- a/src/system-node.js
+++ b/src/system-node.js
@@ -1,6 +1,7 @@
 import './features/resolve.js';
 import './features/registry.js';
 import './features/fetch-load.js';
+import './features/node-sourcemap.js';
 import './features/node-fetch.js';
 import './extras/global.js';
 

--- a/test/fixtures/register-modules/sourcemap-original.js
+++ b/test/fixtures/register-modules/sourcemap-original.js
@@ -1,0 +1,8 @@
+// This is the "original source" that the source map points to.
+// Line 1: comment
+// Line 2: comment
+// Line 3: comment
+// Line 4: comment
+function originalThrow() {
+  throw new Error('source map test error');
+}

--- a/test/fixtures/register-modules/sourcemap-throwing.js
+++ b/test/fixtures/register-modules/sourcemap-throwing.js
@@ -1,0 +1,13 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [],
+    execute: function () {
+      _export("throwError", function throwError() {
+        throw new Error('source map test error');
+      });
+    }
+  };
+});
+//# sourceMappingURL=sourcemap-throwing.js.map

--- a/test/fixtures/register-modules/sourcemap-throwing.js.map
+++ b/test/fixtures/register-modules/sourcemap-throwing.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["sourcemap-original.js"],"names":["originalThrow"],"mappings":";;;;;;;MAMEA","file":"sourcemap-throwing.js","sourcesContent":["// This is the \"original source\" that the source map points to.\n// Line 1: comment\n// Line 2: comment\n// Line 3: comment\n// Line 4: comment\nfunction originalThrow() {\n  throw new Error(\"source map test error\");\n}\n"]}

--- a/test/system-node.mjs
+++ b/test/system-node.mjs
@@ -35,6 +35,71 @@ describe('NodeJS version of SystemJS', () => {
     });
   });
 
+  describe('source map support', () => {
+    it('remaps stack traces for modules with source maps', async () => {
+      const url = 'file://' + path.join(process.cwd(), 'test/fixtures/register-modules/sourcemap-throwing.js');
+      const mod = await System.import(url);
+      try {
+        mod.throwError();
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.equal(e.message, 'source map test error');
+        assert.ok(
+          e.stack.includes('sourcemap-original.js'),
+          'Expected stack trace to reference sourcemap-original.js but got:\n' + e.stack
+        );
+      }
+    });
+
+    it('evicts source map cache on System.delete', async () => {
+      const { readFileSync, writeFileSync } = await import('fs');
+      const mapPath = path.join(process.cwd(), 'test/fixtures/register-modules/sourcemap-throwing.js.map');
+      const originalMap = readFileSync(mapPath, 'utf-8');
+
+      const url = 'file://' + path.join(process.cwd(), 'test/fixtures/register-modules/sourcemap-throwing.js');
+
+      // First import — triggers source map URL caching
+      const mod1 = await System.import(url);
+      try { mod1.throwError(); } catch (e) {
+        assert.ok(e.stack.includes('sourcemap-original.js'), 'Initial source map should work');
+      }
+
+      // Swap the .map file to point to a different source name
+      const altMap = originalMap.replace('sourcemap-original.js', 'sourcemap-alt.js');
+      writeFileSync(mapPath, altMap);
+
+      try {
+        // Delete — should evict caches
+        System.delete(url);
+
+        // Re-import — should re-cache the URL and lazily read the modified .map
+        const mod2 = await System.import(url);
+        try { mod2.throwError(); } catch (e) {
+          assert.ok(
+            e.stack.includes('sourcemap-alt.js'),
+            'Expected stack trace to reference sourcemap-alt.js (proving cache was evicted) but got:\n' + e.stack
+          );
+        }
+      } finally {
+        // Restore original .map file
+        writeFileSync(mapPath, originalMap);
+      }
+    });
+
+    it('preserves stack traces for modules without source maps', async () => {
+      const url = 'file://' + path.join(process.cwd(), 'test/fixtures/register-modules/deperror.js');
+      try {
+        await System.import(url);
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.ok(
+          e.stack.includes('deperror.js'),
+          'Expected stack trace to reference deperror.js but got:\n' + e.stack
+        );
+      }
+    });
+  });
+
   describe('import maps', () => {
     it('can load a module from the network', async () => {
       applyImportMap(System, {imports: {"rxjs": "https://cdn.jsdelivr.net/npm/@esm-bundle/rxjs@6.5.4-fix.0/system/rxjs.min.js"}});


### PR DESCRIPTION
[For Discussion] ** Breaking Changes** 

The breaking change is the Minimum Node version, this doesn't add new functionality, but instead focuses on removing some large polyfills.

Node only changes

Build/tooling:
* Switch Node bundler from NCC (webpack) to Rollup
* Remove node-fetch, source-map-support, @vercel/ncc dependencies
* Add ESM output (dist/system-node.mjs)
* Node Bundle size: 506KB → ~31KB

Runtime:
* Require native fetch for http://
* Document how to polyfill fetch for http users using (Node < 18.13)
* Make missing fetch non-fatal for file:// users
* Make source-map-support warn, and then no-op for stack traces (Node < 20)
* Evict source map caches on System.delete
* Add engines field (>=18.13.0)

Other:
* Change package.json type from "script" to "commonjs"
* Add ESM export condition to package.json exports map
* Add source map tests (3 tests)
* Update README and docs/nodejs.md

Todo:
- [ ]  Consider Typescript types - or validate @types/systemjs is up to date (update @types/systemjs for 7.x)
- [ ] could importing system.js be isomorphic - or should it remain as distinct entrypoint?
- [ ] consider package.json type: module
- [ ] Document issues with extras/global - suggest making opt-in only
- [ ] Consider https://html.spec.whatwg.org/multipage/webappapis.html#merge-existing-and-new-import-maps